### PR TITLE
Remove "openseadragon fix" section of install script

### DIFF
--- a/apache/isle_drupal_build_tools/install_isle_ld_site.sh
+++ b/apache/isle_drupal_build_tools/install_isle_ld_site.sh
@@ -21,25 +21,6 @@ cp -rv /tmp/drupal_install/. /var/www/html/
 echo "Copy /tmp/settings.php to /var/www/html/sites/default/settings.php"
 cp -v /tmp/settings.php /var/www/html/sites/default/
 
-# drush openseadragon-plugin in drupal.drush.make should pull 2.2.1 - cm 20180316
-# echo "Fix Openseadragon & Change directory to /var/www/html/sites/all/libraries"
-# cd /var/www/html/sites/all/libraries || exit
-
-# echo "Delete current broken openseadragon library"
-# rm -rf /var/www/html/sites/all/libraries/openseadragon
-
-# echo "Download Openseadragon Library 2.2.1.zip"
-# wget https://github.com/openseadragon/openseadragon/releases/download/v2.2.1/openseadragon-bin-2.2.1.zip
-
-# echo "Unzip Openseadragon Library"
-# unzip /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1.zip
-
-# echo "mv openseadragon-bin-2.2.1 openseadragon"
-# mv /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1 /var/www/html/sites/all/libraries/openseadragon
-
-# echo "Delete Openseadragon zipfile"
-# rm /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1.zip
-
 echo "Installing all Islandora modules"
 cd /var/www/html/sites/all/modules || exit
 

--- a/apache/isle_drupal_build_tools/install_isle_ld_site.sh
+++ b/apache/isle_drupal_build_tools/install_isle_ld_site.sh
@@ -21,23 +21,24 @@ cp -rv /tmp/drupal_install/. /var/www/html/
 echo "Copy /tmp/settings.php to /var/www/html/sites/default/settings.php"
 cp -v /tmp/settings.php /var/www/html/sites/default/
 
-echo "Fix Openseadragon & Change directory to /var/www/html/sites/all/libraries"
-cd /var/www/html/sites/all/libraries || exit
+# drush openseadragon-plugin in drupal.drush.make should pull 2.2.1 - cm 20180316
+# echo "Fix Openseadragon & Change directory to /var/www/html/sites/all/libraries"
+# cd /var/www/html/sites/all/libraries || exit
 
-echo "Delete current broken openseadragon library"
-rm -rf /var/www/html/sites/all/libraries/openseadragon
+# echo "Delete current broken openseadragon library"
+# rm -rf /var/www/html/sites/all/libraries/openseadragon
 
-echo "Download Openseadragon Library 2.2.1.zip"
-wget https://github.com/openseadragon/openseadragon/releases/download/v2.2.1/openseadragon-bin-2.2.1.zip
+# echo "Download Openseadragon Library 2.2.1.zip"
+# wget https://github.com/openseadragon/openseadragon/releases/download/v2.2.1/openseadragon-bin-2.2.1.zip
 
-echo "Unzip Openseadragon Library"
-unzip /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1.zip
+# echo "Unzip Openseadragon Library"
+# unzip /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1.zip
 
-echo "mv openseadragon-bin-2.2.1 openseadragon"
-mv /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1 /var/www/html/sites/all/libraries/openseadragon
+# echo "mv openseadragon-bin-2.2.1 openseadragon"
+# mv /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1 /var/www/html/sites/all/libraries/openseadragon
 
-echo "Delete Openseadragon zipfile"
-rm /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1.zip
+# echo "Delete Openseadragon zipfile"
+# rm /var/www/html/sites/all/libraries/openseadragon-bin-2.2.1.zip
 
 echo "Installing all Islandora modules"
 cd /var/www/html/sites/all/modules || exit


### PR DESCRIPTION
OSD fix introduced extra step: 
1. Delete OSD library introduced with module install in drupal and islandora drush makefiles 
2. Download/install 2.2.1 library directly from OSD source
3. Overwrite direct install with `drush openseadragon-plugin` (pulls 2.3.1) 
Notes: 
* Release managers confirmed latest update (2.3.1) should be used across the board 
* Tested in local install to ensure result of deleted fix is the same as original process (ends up with 2.3.1, no apparent conflict or error)
* There is background context/testing; happy to discuss in Issues if clarification needed.