### PR TITLE
Sets a Traefik version, 1.6.6.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
       - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
 
   traefik:
-    image: traefik:latest
+    image: traefik:1.6
     container_name: isle-proxy-${CONTAINER_SHORT_ID}
     networks:
       isle-internal:


### PR DESCRIPTION
Traefik 1.7 is causing headaches and until we can address this issue we'll need to use 1.6.x