### PR TITLE
ISLE 1.1.01

### DIFF
--- a/.env
+++ b/.env
@@ -34,6 +34,16 @@ DRUPAL_DB_PASS=isle_ld_db2018
 ## Database (SQL) end.
 
 
+## ISLE Drupal Build tools:
+
+# Pull build tools from git repo?  bool (true|false), default: true
+PULL_ISLE_BUILD_TOOLS=true
+
+# Repo and branch to pull?
+ISLE_BUILD_TOOLS_REPO=https://github.com/Islandora-Collaboration-Group/isle_drupal_build_tools.git
+ISLE_BUILD_TOOLS_BRANCH=7.x-1.11
+
+
 ## Islandora (DRUPAL)
 
 ### Site name 

--- a/config/proxy/traefik.toml
+++ b/config/proxy/traefik.toml
@@ -117,7 +117,8 @@ defaultEntryPoints = ["http", "https"]
 endpoint = "unix:///var/run/docker.sock"
 exposedbydefault = false
 watch = true
-usebindportip = true
+
+## usebindportip = true ## deprecated per Traefik developers.
 
 # Use Swarm Mode services as data provider.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,10 +109,8 @@ services:
   apache:
     # build:
     #   context: ./images/isle-apache
-    image: islandoracollabgroup/isle-apache:1.1
+    image: islandoracollabgroup/isle-apache:development
     container_name: isle-apache-${CONTAINER_SHORT_ID}
-    environment:
-      - PULL_ISLE_BUILD_TOOLS=true # Defaults to true.
     env_file: 
       - .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
   apache:
     # build:
     #   context: ./images/isle-apache
-    image: islandoracollabgroup/isle-apache:development
+    image: islandoracollabgroup/isle-apache:1.1
     container_name: isle-apache-${CONTAINER_SHORT_ID}
     env_file: 
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
 
   traefik:
-    image: traefik:latest
+    image: traefik:1.6
     container_name: isle-proxy-${CONTAINER_SHORT_ID}
     networks:
       isle-internal:


### PR DESCRIPTION
Adds in and resolves:

- Pulling from remote git set in .env
- Pulling from specific branch
- Resolves Fedora fix-attribs.d from taking about three lifetimes to update permissions on large datastores.
- Multi-Threads Fedora Generic Search and adds a helper script to easily kick the reindex process off.
- I'm leaving this here because I always forget something.
- Resolves Traefik issues though for the time
- In another commit will update the images folder to point to the most recent HASHes as per the builds on Docker Hub (removed any reference from original benjaminrosner development docker hubs)
- In another commit will update the images from their :development to :1.1 once that change is done.

This is a non-breaking commit to the 1.1 branch and does not require any special attention for end users.
@Islandora-Collaboration-Group/icg-documentation this PR will req. some documentation on the new ENV_VARs and the helper script. 

PLEASE DO NOT MERGE THIS PR! 