### PR TITLE
Introduced small .env change and docker-compose.override.yml

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,9 @@
 COMPOSE_PROJECT_NAME=isledevelopment
-
-BASE_DOMAIN=isle.localdomain
-
 CONTAINER_SHORT_ID=ld
+
+### Domain names.  FULL_DOMAIN is the full address, with a prepended SUBDOMAIN, of your ISLE site.  It should include any subdomain followed by .BASE_DOMAIN
+BASE_DOMAIN=grinnell.edu
+FULL_DOMAIN=dgdockerx.grinnell.edu
 
 ## Windows user should uncomment the following line:
 # COMPOSE_CONVERT_WINDOWS_PATHS=1

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+#### docker-compose up -d;
+## Updated 2018-09-07 - Release 1.1 (@ 1.1)
+
+services:
+
+  isle-portainer: ## Renamed to avoid conflicts on systems/servers with portainer already running.
+    labels:
+      - "traefik.frontend.rule=Host:portainerx.${BASE_DOMAIN};"
+
+#  fedora:
+#    volumes:
+#      - /home/islandora/opt/FEDORA/data/datastreamStore:/usr/local/fedora/data/datastreamStore
+#      - /home/islandora/opt/FEDORA/data/objectStore:/usr/local/fedora/data/objectStore 
+#      - /home/islandora/opt/FEDORA/data/fedora-xacml-policies:/usr/local/fedora/data/fedora-xacml-policies
+
+  apache:
+    labels:
+      - "traefik.frontend.rule=Host:${FULL_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
+
+  traefik:
+    labels:
+      - traefik.frontend.rule=Host:traefikx.${BASE_DOMAIN};
+


### PR DESCRIPTION
I've been doing extensive testing of ISLE v1.1 requiring frequent changes to `docker-compose.yml`.  Lately I've started using the `override` feature of `docker-compose` and suggest adoption of this feature in ISLE going forward.  The capabilities of this feature are documented at https://docs.docker.com/compose/extends/. 

This PR added a very small addition to the existing `.env` file, and takes advantage of that addition by introducing a new `docker-compose.override.yml` file into the stack. 