### PR TITLE
Clarify traefik comment in docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - ./logs/imageservices:/usr/local/tomcat/logs
     labels:
       - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
-      ## Making imagge-services accessible via traefik is not safe and not recommended
+      ## Making image-services accessible via traefik is not safe and not recommended
       - traefik.enable=false
       - "traefik.frontend.rule=Host:images.${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
     labels:
       - traefik.port=9000
       - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
-      - traefik.enable=true  ## NOT SAFE FOR PRODUCTION! ##
+      ## Making portainer accessible via traefik is not safe in a production enviroment unless
+      ## you have the ISLE system behind a firewall and, overall, only ports 80 and 443 exposed.
+      - traefik.enable=true
       - "traefik.frontend.rule=Host:portainer.${BASE_DOMAIN};"
 
   mysql:
@@ -145,7 +147,9 @@ services:
       - ./config/proxy/traefik.toml:/etc/traefik/traefik.toml  ## Edit line 27, 28 with your cert and key names.
     labels:
       - traefik.port=8080
-      - traefik.enable=true  ## NOT SAFE FOR PRODUCTION! ##
+      ## Enabling Traefik is not safe in a production enviroment unless you have the ISLE system
+      ## behind a firewall and only ports 80 and 443 exposed.
+      - traefik.enable=true
       - traefik.frontend.rule=Host:admin.${BASE_DOMAIN};
 
 # Defined networks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     labels:
       - traefik.port=9000
       - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
-      ## Making portainer accessible via traefik is not safe in a production enviroment unless
+      ## Enabling access the Portainer interface via traefik is not safe in a production enviroment unless
       ## you have the ISLE system behind a firewall and, overall, only ports 80 and 443 exposed.
       - traefik.enable=true
       - "traefik.frontend.rule=Host:portainer.${BASE_DOMAIN};"
@@ -44,7 +44,7 @@ services:
     environment:
       - JAVA_MAX_MEM=768M
       - JAVA_MIN_MEM=128M
-    env_file: 
+    env_file:
       - tomcat.env
       - .env
     networks:
@@ -91,7 +91,7 @@ services:
     environment:
       - JAVA_MAX_MEM=512M
       - JAVA_MIN_MEM=0
-    env_file: 
+    env_file:
       - tomcat.env
       - .env
     networks:
@@ -105,6 +105,7 @@ services:
       - ./logs/imageservices:/usr/local/tomcat/logs
     labels:
       - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
+      ## Making imagge-services accessible via traefik is not safe and not recommended
       - traefik.enable=false
       - "traefik.frontend.rule=Host:images.${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
 
@@ -113,7 +114,7 @@ services:
     #   context: ../images/isle-apache
     image: islandoracollabgroup/isle-apache:1.1.1
     container_name: isle-apache-${CONTAINER_SHORT_ID}
-    env_file: 
+    env_file:
       - .env
     networks:
       isle-internal:
@@ -147,8 +148,8 @@ services:
       - ./config/proxy/traefik.toml:/etc/traefik/traefik.toml  ## Edit line 27, 28 with your cert and key names.
     labels:
       - traefik.port=8080
-      ## Enabling Traefik is not safe in a production enviroment unless you have the ISLE system
-      ## behind a firewall and only ports 80 and 443 exposed.
+      ## Enabling access to the Traefik interface is not safe in a production enviroment unless you have the
+      ## ISLE system behind a firewall and only ports 80 and 443 exposed.
       - traefik.enable=true
       - traefik.frontend.rule=Host:admin.${BASE_DOMAIN};
 


### PR DESCRIPTION
This essentially clarifies the "NOT SAFE FOR PRODUCTION" comment in the docker-compose file around enabling traefik on certain services.

I tried to keep the comments brief and am open to ideas about the wording of the comments.  

This fixes https://github.com/Islandora-Collaboration-Group/ISLE/issues/221