### PR TITLE
Missing php uploadprogress extension line in all php.*.ini files. Added.

### DIFF
--- a/config/apache/php_ini/php.demo.ini
+++ b/config/apache/php_ini/php.demo.ini
@@ -2039,3 +2039,4 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+extension=uploadprogress.so

--- a/config/apache/php_ini/php.local.ini
+++ b/config/apache/php_ini/php.local.ini
@@ -2039,3 +2039,4 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+extension=uploadprogress.so

--- a/config/apache/php_ini/php.production.ini
+++ b/config/apache/php_ini/php.production.ini
@@ -2039,3 +2039,4 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+extension=uploadprogress.so

--- a/config/apache/php_ini/php.test.ini
+++ b/config/apache/php_ini/php.test.ini
@@ -2039,3 +2039,4 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+extension=uploadprogress.so

--- a/config/apache/php_ini/php_staging.ini
+++ b/config/apache/php_ini/php_staging.ini
@@ -2039,3 +2039,4 @@ ldap.max_links = -1
 ; Local Variables:
 ; tab-width: 4
 ; End:
+extension=uploadprogress.so


### PR DESCRIPTION
Missing php uploadprogress extension line in all php.*.ini files. Added. This allows the PHP upload progress bars to display properly https://www.drupal.org/node/793264