### PR TITLE
Suggested improvement to make intended workflow more clear

### DIFF
--- a/docs/install/install-local-migrate.md
+++ b/docs/install/install-local-migrate.md
@@ -237,17 +237,19 @@ This step assumes you have an existing Islandora Drupal site checked into a git 
 
 Using the still open `terminal` (Windows: `PowerShell`):
 
-* Create a local bind-mount (persistent) and store your Production Islandora Drupal site code outside of your ISLE directory
-* While you may create your new bind-mount directory anywhere, we suggest that you put it at the same level as your existing ISLE directory.
-* `cd ..`
-* `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
-    * Example: The above process created a folder named "yourprojectnamehere-islandora"
-* Open `docker-compose.local.yml`
+* Create a location outside of your ISLE directory where your Islandora Drupal site code will be stored.
+  While you may create this location anywhere, we suggest that you put it at the same level as your existing ISLE directory.
+    * From your ISLE directory:
+        * `cd ..`
+        * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
+        * Example: The above process created a folder named "yourprojectnamehere-islandora"
+* Now update the `docker-compose.local.yml` in the ISLE repository to create a bind-mount to the Islandora Drupal site code:
     * Search for "apache:"
     * Find the sub-section called "volumes:"
     * Find this line: "- ./data/apache/html:/var/www/html:cached"
-    * Edit the above line to be like this: ` - ../yourprojectnamehere-islandora:/var/www/html:cached`
-* Your bind-mount is now complete.
+    * Edit the above line to be like this:
+        * ` - ../yourprojectnamehere-islandora:/var/www/html:cached`
+* Your Production Islandora site code is now configured to be used in this local setup.
 
 ---
 

--- a/docs/install/install-local-migrate.md
+++ b/docs/install/install-local-migrate.md
@@ -231,17 +231,23 @@ Continue the local setup as directed below and ultimately import some objects fr
 
 ## Step 3: Git Clone the Production Islandora Drupal Site Code
 
-This step assumes you have an existing Drupal /Islandora site checked into a git repository.
+This step assumes you have an existing Islandora Drupal site checked into a git repository. (If not, then you'll need to check your Drupal site into a git repository following the same commands from [Local ISLE Installation: New Site](../install/install-local-new.md) documentation.)
 
-If not then you'll need to check your Drupal site into a git repo following the same commands from [Local ISLE Installation: New Site](../install/install-local-new.md) documentation.
+**Note:** If below you see a "fatal: Could not read from remote repository." error, then please read [Fatal: Could not read from remote repository](../install/install-troubleshooting.md#fatal-could-not-read-from-remote-repository).
 
 Using the still open `terminal` (Windows: `PowerShell`):
 
-* `mkdir -p data/apache/html`
-* `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git data/apache/html`
-    * (Optional) You can chose another directory of your choice as the bind-mounts match in the Apache services volume section within the `docker-compose.local.yml` matches that other location
-
-* Move the previously copied Production Islandora Drupal `files` directory to inside the `data/apache/html/sites/default/` directory.
+* Create a local bind-mount (persistent) and store your Production Islandora Drupal site code outside of your ISLE directory
+* While you may create your new bind-mount directory anywhere, we suggest that you put it at the same level as your existing ISLE directory.
+* `cd ..`
+* `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
+    * Example: The above process created a folder named "yourprojectnamehere-islandora"
+* Open `docker-compose.local.yml`
+    * Search for "apache:"
+    * Find the sub-section called "volumes:"
+    * Find this line: "- ./data/apache/html:/var/www/html:cached"
+    * Edit the above line to be like this: ` - ../yourprojectnamehere-islandora:/var/www/html:cached`
+* Your bind-mount is now complete.
 
 ---
 


### PR DESCRIPTION
I am suggesting this improvement to Step 3 on the [install-local-migrate](https://islandora-collaboration-group.github.io/ISLE/install/install-local-migrate/#step-3-git-clone-the-production-islandora-drupal-site-code) docs page. 

This PR puts the two required repositories (`mysite-islandora` and `mysite-isle`) next to each other, instead of nesting the `mysite-islandora` within the `mysite-isle`'s `data/apache/html` folder.

I think separating these two repos makes it easier to:
- understand bind-mounts
- blow up and re-clone either repo, if necessary, w/o the overhead of having to remember to reclone an interior nested repo as well.

Ultimately, developers can do -- or nest -- as they wish, however, I think that recommending the nested route adds complexity, when our real job here is to convey the idea of having a similar workflow that extends from Local to Staging to Production.

I recognize that, if this PR is accepted, I will also need to update related text within the `install-local-new` doc.

I invite others to share your thoughts and opinions.