### PR TITLE
Docs: Eliminating Local Window Installation Failure Points

### DIFF
--- a/docs/appendices/glossary.md
+++ b/docs/appendices/glossary.md
@@ -42,8 +42,6 @@ a server you connected to via ssh (REMOTE).
 
 ## Documentation / Development
 
-* **CLI / cli** - A command-line interface or command language interpreter (CLI), also known as command-line user interface, console user interface[1] and character user interface (CUI), is a means of interacting with a computer program where the user (or client) issues commands to the program in the form of successive lines of text (command lines). A program which handles the interface is called a command language interpreter or shell.
-
 * **Git** - A free and open source distributed software version control system designed to handle everything from small to very large projects with speed and efficiency. Git is easy to learn and has a tiny footprint with lightning fast performance.
     * [https://git-scm.com/](https://git-scm.com/)
     * The ISLE project and its documentation is hosted by an online git service called [Github.com](https://github.com/)
@@ -55,6 +53,8 @@ a server you connected to via ssh (REMOTE).
     * [https://daringfireball.net/projects/markdown/syntax](https://daringfireball.net/projects/markdown/syntax)
     * [http://kirkstrobeck.github.io/whatismarkdown.com/](http://kirkstrobeck.github.io/whatismarkdown.com/)
     * [https://help.github.com/categories/writing-on-github/](https://help.github.com/categories/writing-on-github/)
+
+* **Terminal (CLI)** - A command-line interface or command language interpreter (CLI), also known as command-line user interface, console user interface[1] and character user interface (CUI), is a means of interacting with a computer program where the user (or client) issues commands to the program in the form of successive lines of text (command lines). A program which handles the interface is called a command language interpreter or shell.
 
 * **TL;DR** - "Too long; didn't read." - used to indicate a large post, article, etc. that has a brief summary of said post, article, etc. as it might be too long to read.
 

--- a/docs/appendices/sample-it-department-request.md
+++ b/docs/appendices/sample-it-department-request.md
@@ -11,8 +11,8 @@ We require access to a server meeting the following [Hardware Requirements](../i
  * Ubuntu 18.04 LTS or CentOS 7.x running on a server or virtual machine
  * Minimum 2 CPU's (w/1-4 cores each)
  * Sufficient hard drive or attached storage to hold your collection
- * 30 - 50GB for the server OS and overhead
- * 16 - 32 GB of RAM
+ * 30-50GB for the server OS and overhead
+ * 16-32 GB of RAM
 
 Our team will either need root access, or a user called "islandora" that has sudo privileges.
 

--- a/docs/contributor-docs/ISLE-v.1.1.2-buildnotes.md
+++ b/docs/contributor-docs/ISLE-v.1.1.2-buildnotes.md
@@ -17,7 +17,7 @@
     * `docker-compose up -d`
   * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
   * Install Islandora on the isle-apache-ld container:
-  * `docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
+  * `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
     * Please note this will run the `https://github.com/Born-Digital-US/ISLE-Drupal-Build-Tools.git` version which has changes to the installer vsets.
 
 * Recommend a test of all ingest and content types and especially Large Image format using the open-seadragon viewer.

--- a/docs/contributor-docs/build-guide-v111.md
+++ b/docs/contributor-docs/build-guide-v111.md
@@ -374,13 +374,13 @@ The following software packages will be handled and updated by `apt-get`. Please
     * `git checkout last used build commit` i.e. `git checkout ee7e9d32a71381abfa5c3ead13255c0c5b66ed45`
     * Compare both directories using a visual diff tool like `Kaleidoscope` (MAC), `diff` or `KDiff3` (Linux)
     * Note the differences in files and the line numbers for inclusion in release notes.
-      * `datastream_info_to_solr.xslt` - Lines 35 - 49 - new lines & content added
+      * `datastream_info_to_solr.xslt` - Lines 35-49 - new lines & content added
       * `RELS-EXT_to_solr.xslt`
         * Line 7 - modified
         * Line 8 - new line & content added
         * Line 42 - new line & content added
         * Line 49 - new line & content added
-      * `slurp_all_MODS_to_solr.xslt` - Lines 289 - 300 new lines & content added
+      * `slurp_all_MODS_to_solr.xslt` - Lines 289-300 new lines & content added
 
 #### isle-fedora - Build Actions / Steps
 
@@ -938,7 +938,7 @@ Suggested outcome:
   * Did all containers start?
 
 * Install site
-  * `docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
+  * `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
 
 * Test ingest for all content types
 

--- a/docs/contributor-docs/editing-local.md
+++ b/docs/contributor-docs/editing-local.md
@@ -35,7 +35,7 @@ The example used below is how to create a new documentation page that will be ab
 
 * Create a new empty file in the `docs/contributor-docs` directory e.g. `building_giant_robots.md`
 
-* Open up the `mkdocs.yml` file in a text editor.
+* Open the `mkdocs.yml` file in a text editor.
 
 In order for `mkdocs` to understand that there is a new page and page title to display in the rendered documentation, one must use the YAML code convention (syntax) to enter.
 

--- a/docs/contributor-docs/style-guide.md
+++ b/docs/contributor-docs/style-guide.md
@@ -31,15 +31,17 @@ Sections within a section that is specific to a certain type of circumstance sho
 ---
 
 ## Headers: Follow the APA Style Guide for Capitalization of All Important Words.
-### For example:
+- Solution: Sublime Text 3, install and use this package: `Smart Title Case.sublime-package`
+
+### **Example:**
 - H1: Page Title
 - H2: Main Subheaders
-- H3: Subheaders found within "Main Subheaders"
+- H3: Copy Production Data to Your Local
 
 ---
 
 ## Bullets and Indentations
-### For example:
+### **Example:**
 Mkdocs is finicky and requires double indentations to create properly indented sub-bullets.
 
 * Item A

--- a/docs/cookbook-recipes/isle-cheatsheet-docker-commands.md
+++ b/docs/cookbook-recipes/isle-cheatsheet-docker-commands.md
@@ -46,8 +46,8 @@ Docker commands that are useful to installing or updating ISLE.
 ### [Shell Into Docker Container](https://docs.docker.com/v17.12/engine/reference/commandline/exec/)
   * `docker exec -it [CONTAINER_NAME] bash` # Shell Into Docker Container
     * example: `docker exec -it isle-apache-ld bash`
-  * `docker exec -it [CONTAINER_NAME] [FILE_NAME]` # Shell Into Docker Container and Open a File
-    * example: `docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
+  * `docker exec -it [CONTAINER_NAME] [FILE_NAME]` # Shell Into Docker Container and Run Script
+    * example: `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
 
 ### [Docker Service](https://docs.docker.com/engine/reference/commandline/docker/)
   * `sudo service docker status` # Show Docker Status

--- a/docs/install/_obsolete_install-server.md
+++ b/docs/install/_obsolete_install-server.md
@@ -1,6 +1,6 @@
 # Remote Server ISLE Installation
 
-_Expectations:  It may take at least **4 - 6 hours or more** to read this documentation and complete this installation. Please proceed slowly._
+_Expectations:  It may take at least **4-6 hours or more** to read this documentation and complete this installation. Please proceed slowly._
 
 This Remote Server ISLE Installation creates an Islandora environment with a unique domain (URL) on your host server, virtual machine, or cloud hosted platform.
 You may also use this documentation to install ISLE on several host servers, virtual machines, or cloud hosted platforms to create multiple Islandora environments (e.g. development, staging, and production). This process will result in an un-themed Drupal website and an empty Fedora repository. (Please refer back to the [Hardware Requirements](../install/host-hardware-requirements.md) as the development environment needs fewer resources than the staging and production environments; the latter two should mirror each other in resource usage and setup.)
@@ -190,13 +190,11 @@ docker-compose up -d
 * Wait for the stack to completely initialize.
 
 
-This process may take 10 - 20 minutes (_depending on system and internet speeds_)
+This process may take 10-20 minutes (_depending on system and internet speeds_)
 
 * Run the install site script on the Apache container by copying and pasting this command:
 [TODO: A server install should not be told to run this script: we want the install to be persistent, not ephemeral.]
-```
-docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh
-```
+    * `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
 
 * Check the newly created and running new site by opening a browser and navigating to your site domain e.g. `https://project-name.yourdomain.edu`, you should now see an un-themed Drupal site.
 

--- a/docs/install/host-hardware-requirements.md
+++ b/docs/install/host-hardware-requirements.md
@@ -25,9 +25,9 @@ If you need help requesting a server environment, please see the [Sample IT Depa
 Below are the recommended minimum specifications for a production server. The server can be a local or hosted physical server or virtual machine, or it can be a cloud hosted platform (AWS, GCP, etc.).  
 
 * Ubuntu 18.04 LTS or CentOS 7.x running on a server or virtual machine
-* Minimum 2 CPU's (with 1 - 4 cores each)
-* 16 - 32 GB of RAM is recommended
-* 30 - 50GB for the server OS and overhead
+* Minimum 2 CPU's (with 1-4 cores each)
+* 16-32 GB of RAM is recommended
+* 30-50GB for the server OS and overhead
 * Sufficient hard drive or attached storage to hold your collection
 
 | For Migrations only |
@@ -43,9 +43,9 @@ Below are the recommended minimum specifications for a production server. The se
 Below are the recommended minimum specifications for a staging server. The server can be a local or hosted physical server or virtual machine, or it can be a cloud hosted platform (AWS, GCP, etc.).  
 
 * Ubuntu 18.04 LTS or CentOS 7.x running on a server or virtual machine
-* Minimum 2 CPU's (with 1 - 4 cores each)
-* 8 - 16 GB of RAM is recommended
-* 30 - 50GB for the server OS and overhead
+* Minimum 2 CPU's (with 1-4 cores each)
+* 8-16 GB of RAM is recommended
+* 30-50GB for the server OS and overhead
 * Sufficient hard drive or attached storage to hold your collection
 
 **Please continue by selecting: [Software Dependencies](../install/host-software-dependencies.md).**
@@ -58,8 +58,8 @@ Below are the recommended specifications for a personal computer running a Demo 
 
 * Your own OS (whatever it is)
 * Minimum of 2 CPU cores
-* 8 - 16 GB of RAM is recommended
-* 128 - 500GB for the Desktop OS
+* 8-16 GB of RAM is recommended
+* 128-500GB for the Desktop OS
 * Sufficient hard drive or attached storage to hold a small test collection (depending on your testing ~5-10GB for objects and their derivatives)
 
 **Please continue by selecting: [Software Dependencies](../install/host-software-dependencies.md).**

--- a/docs/install/host-software-dependencies.md
+++ b/docs/install/host-software-dependencies.md
@@ -84,7 +84,7 @@ sudo usermod -aG docker $USER
 
 Please run these steps as your normal user (not `root`):
 
-* Clone the repository.
+* Clone the repository:
 ```
 git clone https://github.com/Islandora-Collaboration-Group/ISLE.git
 ```
@@ -170,7 +170,7 @@ sudo usermod -aG docker $USER
 
 Please run these steps as your normal user (not `root`):
 
-* Clone the repository.
+* Clone the repository:
 ```
 git clone https://github.com/Islandora-Collaboration-Group/ISLE.git
 ```
@@ -197,7 +197,7 @@ Git must be installed to get a copy (called a `clone`) of the current ISLE proje
 
  * Open a `terminal` (launch Spotlight, type "Terminal," double-click result "Terminal")
  * Enter: `git --version`.
- * If git is already installed, the above command will output the installed version number. For example:  
+ * If git is already installed, the above command will output the installed version number. **Example:**  
 
 ```
 $git --version
@@ -228,7 +228,7 @@ git version 2.15.1
 
 * As instructed within the prompt, drag and drop the whale icon to the right towards the `Applications` directory shortcut, a tiny green plus sign should appear, now let go from the mouse or trackpad.
 
-* The application should start to copy data to the `Applications` directory, this process may take 1 - 5 mins depending on the speed of your hard-drive.
+* The application should start to copy data to the `Applications` directory, this process may take 1-5 mins depending on the speed of your hard-drive.
 
 * Launch the `Docker` application from the `Applications` directory
 
@@ -245,7 +245,7 @@ git version 2.15.1
 
 Please run these steps as your normal user (not `root`):
 
-* Clone the repository.
+* Clone the repository:
 ```
 git clone https://github.com/Islandora-Collaboration-Group/ISLE.git
 ```
@@ -256,7 +256,7 @@ cd ISLE
 ```
 _To improve performance on Mac OSX:_
 
-* Open `docker-compose.yml` in a text editor and go to the the `apache` section
+* Open "docker-compose.yml" in a text editor and go to the the `apache` section
 * Under `volumes` find the following line:
     * `- ./mnt/html:/var/www/html`
     * Change to: `- ./mnt/html:/var/www/html:cached`
@@ -273,24 +273,21 @@ Your host server is now configured and ready to run ISLE.
 
 ## Windows
 
-### Step 1: Install Git
+### Step 1: Install "Git for Windows"
 Git must be installed to get a copy (called a `clone`) of the current ISLE project. (Git is a software version control system for tracking changes in computer files and coordinating work on those files among multiple people.)
 
 * Press the Windows key.
-* Type `PowerShell`.
-* In the search results, RIGHT-CLICK `Windows PowerShell`, select `Run as administrator`, and enter `Yes` to prompt.
-* Enter: `git --version`.
-* If git is already installed, the above command will output the installed version number. For example:  
-
-```
-$git --version
-git version 2.15.1
-```
-
-* If git is not installed, then
-    * [Download Git for Windows](https://gitforwindows.org/).
-    * Click `Download`, `Save` the file to your Desktop, `double-click` that file to install, then click `Yes` to the prompt.
-    * Click `Next` to accept all of the installer's default selections.
+* Type `Git Bash`.
+    * If you have "Git Bash" installed, then RIGHT-CLICK `Git Bash`, select `Run as administrator`, and enter `Yes` to the prompt.
+        * Enter: `git --version`.
+            * If git is already installed, the above command will output the installed version number. **Example:** "git version 2.23.0.windows.1"
+    * Otherwise, you must install "Git Bash".
+        * [Download "Git for Windows"](https://gitforwindows.org/).
+        * Click `Download`, `Save` the file to your Desktop, `double-click` that file to install, then click `Yes` to the prompt.
+        * Click `Next` and accept all of the installer's default selections.
+            * Optional: **Choosing the default editor used by Git** - Select preferred text editor. [ATOM](https://atom.io/) integrates particularly nicely with Git for Windows.
+    * Check for updates:
+        * Enter: `git update-git-for-windows`
 
 ### Step 2: Install Docker Desktop for Windows
 
@@ -328,10 +325,9 @@ git version 2.15.1
 ### Step 4: Clone ISLE Repository
 **Please note:** The location you select to clone the ISLE repository becomes your project directory. We recommend using the default user home directory; this location will include your configuration and log output of the Docker containers. (You may choose a different location, but it must not be a protected folder such as system or root directory.)
 
-* Use `PowerShell` (and remember to `Run as administrator`).
+* Use `Git Bash` (and remember to `Run as administrator`).
 * Enter `cd ~` (to change to the user's home directory).
-* Clone the repository.
-
+* Clone the repository:
 ```
 git clone https://github.com/Islandora-Collaboration-Group/ISLE.git
 ```

--- a/docs/install/install-demo.md
+++ b/docs/install/install-demo.md
@@ -61,8 +61,8 @@ Enable the Demo ISLE Installation to be viewed locally on personal computer brow
 This process may take 10-20 minutes (_depending on system and internet speeds_)
 
 * Run the install site script on the Apache container by copying and pasting the appropriate command:
-    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
-    * **For Microsoft Windows:** `winpty docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh"`
+    * **For Microsoft Windows:** `winpty docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh"`
 
 
 | Microsoft Windows |

--- a/docs/install/install-demo.md
+++ b/docs/install/install-demo.md
@@ -16,9 +16,11 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have already git cloned the ISLE Project to your personal computer.
 
+* **For Microsoft Windows:** You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git BASH" as your command line interface; this behaves more similarly to LINUX and UNIX environments.
+
 ---
 
-## Step 1: Edit `/etc/hosts` File
+## Step 1: Edit "/etc/hosts" File
 
 Enable the Demo ISLE Installation to be viewed locally on personal computer browser as: `https://isle.localdomain`.
 
@@ -26,9 +28,9 @@ Enable the Demo ISLE Installation to be viewed locally on personal computer brow
 
 ---
 
-## Step 2: Download the ISLE images
+## Step 2: Download the ISLE Images
 
-* Open a `terminal` (Windows: open `PowerShell`)
+* Open a `terminal` (Windows: open `Git Bash`)
 
 * Navigate to your ISLE project directory. (You may already be in this directory if you are coming from the [Software Dependencies](../install/host-software-dependencies.md).)
 
@@ -39,13 +41,13 @@ Enable the Demo ISLE Installation to be viewed locally on personal computer brow
 
 ## Step 3: Launch Process
 
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * `docker-compose up -d`
   * **Please note:** the “ -d” argument stands for “detached” meaning the command will persist even if you close your terminal or your computer sleeps etc…)
 
 * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
 
-* After the above process is completed using the already open terminal or Powershell again.
+* _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
     * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
@@ -54,17 +56,16 @@ Enable the Demo ISLE Installation to be viewed locally on personal computer brow
 
 ---
 
-## Step 4: Run Islandora Drupal site Install Script
+## Step 4: Run Islandora Drupal Site Install Script
 
-This process may take 10 - 20 minutes (_depending on system and internet speeds_)
+This process may take 10-20 minutes (_depending on system and internet speeds_)
 
-* Run the install site script on the Apache container by copying and pasting this command:
-```
-docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh
-```
+* Run the install site script on the Apache container by copying and pasting the appropriate command:
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
+    * **For Microsoft Windows:** `winpty docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
 
 
-| For Windows Users only |
+| Microsoft Windows |
 | :-------------      |
 | You may be prompted by Windows to: |
 | - Share the C drive with Docker.  Click Okay or Allow.|
@@ -74,7 +75,7 @@ docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isl
 
 * You should see a lot of green [ok] messages.
 * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-* **Proceed only after this message appears:** `Clearing Drupal Caches. 'all' cache was cleared.`
+* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
 
 ---
 

--- a/docs/install/install-local-migrate.md
+++ b/docs/install/install-local-migrate.md
@@ -406,8 +406,7 @@ This step will show you how to run the "migration_site_vsets.sh" script on the A
 Since you've imported an existing Drupal database, you must now reinstall the Islandora solution packs so the Fedora repository will be ready to ingest objects.
 
 * Copy the "install_solution_packs.sh" to the root of the Drupal directory on your Apache container
-    * **For Mac/Ubuntu/CentOS/etc:** `docker cp scripts/apache/install_solution_packs.sh your-apache-containername:/var/www/html/install_solution_packs.sh`
-    * **For Microsoft Windows:** `winpty docker cp scripts/apache/install_solution_packs.sh your-apache-containername:/var/www/html/install_solution_packs.sh`
+    * `docker cp scripts/apache/install_solution_packs.sh your-apache-containername:/var/www/html/install_solution_packs.sh`
 * Change the permissions on the script to make it executable
     * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/install_solution_packs.sh"`
     * **For Microsoft Windows:** `winpty docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/install_solution_packs.sh"`

--- a/docs/install/install-local-migrate.md
+++ b/docs/install/install-local-migrate.md
@@ -1,12 +1,12 @@
 # Local ISLE Installation: Migrate Existing Islandora Site
 
-_Expectations:  It takes an average of **60 - 120 minutes** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **60-120 minutes** to read this documentation and complete this installation._
 
 This `Local` ISLE Installation builds a local environment for the express purpose of migrating a previously existing Islandora site onto the ISLE platform. If you need to build a brand new local development site, please **stop** and use the [Local ISLE Installation: New Site](../install/install-local-new.md) instructions instead.
 
 This `Local` ISLE Installation will use a copy of a currently running Production Islandora Drupal website and an empty Fedora repository for endusers to test migration to ISLE and do site development and design with the end goal of deploying to ISLE Staging and Production environments for public use. The final goal would be to cut over from the existing non-ISLE Production and Staging servers to their new ISLE counterparts.
 
-This `Local` ISLE Installation will allow you to locally view this site in your browser with the domain of your choice (for example: `https://yourprojectnamehere.localdomain`), instead of being constrained to the Demo url (`https://isle.localdomain`).
+This `Local` ISLE Installation will allow you to locally view this site in your browser with the domain of your choice (**Example:** `https://yourprojectnamehere.localdomain`), instead of being constrained to the Demo url (`https://isle.localdomain`).
 
 This document has directions on how you can check in newly created ISLE code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation offers an overview of the ISLE structure, the associated files, and what values ISLE endusers should use for the `.env`, `local.env`, etc.
 
@@ -28,21 +28,22 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have access to a private git repository in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc.
     * If you do not, please contact your IT department for git resources, or else create an account with one of the above providers.
-    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files.
-    * **DO NOT** share these git repositories publicly.
+    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files. **DO NOT** share these git repositories publicly.
 
-* For Windows Users only: You must install [Git for Windows](https://gitforwindows.org/) and use its provided Git BASH command line; this behaves more similarly to LINUX and UNIX environments. (Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.) Git for Windows also installs `openssl.exe` which will be needed to generate self-signed SSL certs.
+* **For Microsoft Windows:**
+    * You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git BASH" as your command line interface; this behaves more similarly to LINUX and UNIX environments. Git for Windows also installs `openssl.exe` which will be needed to generate self-signed SSL certs. (Note: Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.)
+    * Set your text editor to use UNIX style line endings for files. (Text files created on DOS/Windows machines have different line endings than files created on Unix/Linux. DOS uses carriage return and line feed ("\r\n") as a line ending, which Unix uses just line feed ("\n").)
 
 ---
 
 ## Index of Instructions
 
 * Step 0: Copy Production Data to Your Personal Computer
-* Step 1: Edit `/etc/hosts` File
-* Step 2: Setup git for the ISLE Project
+* Step 1: Edit "/etc/hosts" File
+* Step 2: Setup Git for the ISLE Project
 * Step 3: Git Clone the Production Islandora Drupal Site Code
 * Step 4: Edit the .env File to Change to the Local Environment
-* Step 5: Create New Users and Passwords by Editing local.env
+* Step 5: Create New Users and Passwords by Editing "local.env"
 * Step 6: Create New Self-Signed Certs for Your Project
 * Step 7: Download the ISLE Images
 * Step 8: Launch Process
@@ -77,7 +78,7 @@ Be sure to run a backup of any current non-ISLE systems prior to copying or expo
 
 * If possible, on the production Apache webserver, run `drush cc all` from the command line on the production server in the `/var/www/html` directory PRIOR to any db export(s). Otherwise issues can occur on import due to all cache tables being larger than `innodb_log_file_size` allows
 
-#### Production Islandora Drupal site database export process
+#### Export the Production MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current Production Islandora Drupal site in use and copy it to your personal computer (local) in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your Production site.
 
@@ -114,7 +115,7 @@ Bind mount in existing transforms and schemas  to override ISLE settings with yo
 
 * **Please note:** You may need to further review paths in the files mentioned above, and edit them to match ISLE system paths.  
 
-#### Strategy 3: **Advanced** - Diff and Merge Current Production Customization Edits into ISLE Configs
+#### Strategy 3: **Advanced** - Diff and Merge Current Production Customization Edits Into ISLE Configs
 
 * Copy these current production files and directory to your personal computer in an appropriate location.
     * Solr `schema.xml`
@@ -142,7 +143,7 @@ Bind mount in existing transforms and schemas  to override ISLE settings with yo
 
 ---
 
-## Step 1: Edit `/etc/hosts` File
+## Step 1: Edit "/etc/hosts" File
 
 Enable the Local ISLE Installation to be viewed locally on personal computer browser as: e.g. `https://yourprojectnamehere.localdomain`.
 
@@ -152,7 +153,7 @@ Enable the Local ISLE Installation to be viewed locally on personal computer bro
 
 ---
 
-## Step 2: Setup git for the ISLE Project
+## Step 2: Setup Git for the ISLE Project
 
 **Please note:** The commands given below are for command line usage of git. GUI based clients such as the [SourceTree App](https://www.sourcetreeapp.com/) may be easier for endusers to use for the git process.
 
@@ -165,7 +166,7 @@ The git project name can be your institution name or the name of the collections
 
 Clone this newly created ISLE project to your personal computer
 
-    * Open a `terminal` (Windows: open `PowerShell`)
+    * Open a `terminal` (Windows: open `Git Bash`)
     * Navigate to a directory that will house your new ISLE project directory using the `cd` command.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git`
 
@@ -198,23 +199,24 @@ origin	https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-i
 
     * `git push -u origin master`
 
-    * This will take 2 - 5 mins depending on your internet speed.
+    * This will take 2-5 mins depending on your internet speed.
 
 * Now you have the current ISLE project code checked into git as foundation to make changes specific to your local and project needs. You'll use this git "icg-upstream" process in the future to pull updates and releases from the main ISLE project.
 
-### Step 2a: Add Customizations from `Step 0` to the Git Workflow
-This step is intended for users who followed either the "**Intermediate**" or "**Advanced**" migration options in `Step 0` above.  If you choose the **Easy** migration option you may safely skip `Step 2a`.
+### Step 2a: Add Customizations from "Step 0" to the Git Workflow
 
-In your local `ISLE` directory (`cd /path/to/your/repository`) create new directories under `./config` to hold the Solr and GSearch files you retrieved in `Step 0`.  Generally this can be done like so:
+This step is intended for users who followed either the "**Intermediate**" or "**Advanced**" migration options in "Step 0" above.  If you choose the **Easy** migration option you may safely skip `Step 2a`.
+
+In your local `ISLE` directory (`cd /path/to/your/repository`) create new directories under `./config` to hold the Solr and GSearch files you retrieved in "Step 0".  Generally this can be done like so:
 
 ```
 mkdir -p ./config/solr
 mkdir -p ./config/fedora/gsearch
 ```
 
-* Copy your `schema.xml` file from `Step 0` into the new `./config/solr/` directory.
+* Copy your `schema.xml` file from "Step 0" into the new `./config/solr/` directory.
 
-* Copy your `foxmltoSolr.xslt` file and `islandora_transforms` directory from `Step 0` into the `config/fedora/gsearch/` directory.
+* Copy your `foxmltoSolr.xslt` file and `islandora_transforms` directory from "Step 0" into the `config/fedora/gsearch/` directory.
 
 * Add a new line in the Solr volumes section of your `docker-compose.local.yml`  
 ```
@@ -237,7 +239,7 @@ This step assumes you have an existing Islandora Drupal site checked into a git 
 
 **Note:** If below you see a "fatal: Could not read from remote repository." error, then please read [Fatal: Could not read from remote repository](../install/install-troubleshooting.md#fatal-could-not-read-from-remote-repository).
 
-Using the still open `terminal` (Windows: `PowerShell`):
+_Using the same open terminal:_
 
 * Create a location outside of your ISLE directory where your Islandora Drupal site code will be stored.
   While you may create this location anywhere, we suggest that you put it at the same level as your existing ISLE directory.
@@ -257,7 +259,7 @@ Using the still open `terminal` (Windows: `PowerShell`):
 
 ## Step 4: Edit the .env File to Change to the Local Environment
 
-Open a `terminal` (Windows: open `PowerShell`)
+Open a `terminal` (Windows: open `Git Bash`)
 
 * Navigate to your ISLE project directory. (You may already be in this directory if you are coming from the [Software Dependencies](../install/host-software-dependencies.md).)
 
@@ -270,7 +272,7 @@ Open a `terminal` (Windows: open `PowerShell`)
     * `CONTAINER_SHORT_ID=ld` _leave default setting of `ld` as is. Do not change._
     * `COMPOSE_FILE=docker-compose.local.yml`
 
-* If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to open up the `3306` port. If you are already running MySQL on your personal computer, you'll have a port conflict either shutdown that service prior to running ISLE or change 3306:3306 to something like `9306:3306`. Please double-check.
+* If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to Open the `3306` port. If you are already running MySQL on your personal computer, you'll have a port conflict either shutdown that service prior to running ISLE or change 3306:3306 to something like `9306:3306`. Please double-check.
 
 * Enter `Cntrl` and the letter `o` together to write the changes to the file.
 
@@ -279,44 +281,47 @@ Open a `terminal` (Windows: open `PowerShell`)
 **Please note:** We highly recommend that you also review the contents of the `docker-compose.local.yml` file as the Apache service volume section uses bind mounts for the intended Drupal Code instead of using default Docker volumes. This allows users to perform Local Islandora Drupal site development with an IDE. This line is a suggested path and users are free to change values to the left of the `:` to match their Apache data folder of choice. However we recommend starting out with the default setting below.
 Default: `- ./data/apache/html:/var/www/html:cached`
 
-* Additionally, depending on your decision from **Step 0**, you may need to make additional edits to `docker-compose.local.yml` and move files into place as directed from the (**Intermediate**) and (**Advanced**) sections.
+* Additionally, depending on your decision from "Step 0", you may need to make additional edits to `docker-compose.local.yml` and move files into place as directed from the (**Intermediate**) and (**Advanced**) sections.
 
 ---
 
-## Step 5: Create New Users and Passwords by Editing local.env
+## Step 5: Create New Users and Passwords by Editing "local.env"
 
-You can reuse some of the older Production settings in the `local.env` if you like (e.g. the database name `DRUPAL_DB`, database user `DRUPAL_DB_USER` even the drupal database user password `DRUPAL_DB_PASS` if that makes it easier). It is important to avoid repeating passwords in the ISLE Staging and Production environments.
+You can reuse some of the older Production settings in the "local.env" if you like (e.g. the database name `DRUPAL_DB`, database user `DRUPAL_DB_USER` even the drupal database user password `DRUPAL_DB_PASS` if that makes it easier). It is important to avoid repeating passwords in the ISLE Staging and Production environments.
 
-* Open up the `local.env` file in a text editor.
+* Open the "local.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open up the `config/apache/settings_php/settings.local.php` file in a text editor.
+* Open the `config/apache/settings_php/settings.local.php` file in a text editor.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
 
 ---
 
-## Step 6: Create new self-signed certs for your project
+## Step 6: Create New Self-Signed Certs for Your Project
 
-* **Mac/Ubuntu/CentOS/Unix** - Open `./scripts/proxy/ssl-certs/local.sh` in a text editor.
-* **For Windows Users only** - Open `./scripts/proxy/ssl-certs/local-windows-only.sh` in a text editor.
-    * Follow the in-line instructions to add your project's name to the appropriate areas.
+* Open the appropriate file in a text editor:
+    * **For Mac/Ubuntu/CentOS/etc:** `./scripts/proxy/ssl-certs/local.sh`
+    * **For Microsoft Windows:** `./scripts/proxy/ssl-certs/local-windows-only.sh`
+* Follow the in-line instructions to add your project's name to the appropriate areas.
     * Once finished, save and close the file.
 
-* _Using the same open terminal_, navigate to `/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
+* _Using the same open terminal:_, navigate to `/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
     * `cd ./scripts/proxy/ssl-certs/`
-    * **Mac/Ubuntu/CentOS/Unix** - `chmod +x local.sh`
-    * **For Windows Users only** - `chmod +x local-windows-only.sh`
 
-* The following command will generate new self-signed SSL keys using your `yourprojectnamehere.localdomain` domain. This now secures the local site.
-    * **Mac/Ubuntu/CentOS/Unix** - `./local.sh`
-    * **For Windows Users only** - `./local-windows-only.sh`
+* Change the permissions on the script to make it executable
+    * **For Mac/Ubuntu/CentOS/etc:** `chmod +x local.sh`
+    * **For Microsoft Windows:** `chmod +x local-windows-only.sh`
+
+* Run the following command to generate new self-signed SSL keys using your `yourprojectnamehere.localdomain` domain. This now secures the local site.
+    * **For Mac/Ubuntu/CentOS/etc:** `./local.sh`
+    * **For Microsoft Windows:** `./local-windows-only.sh`
     * The generated keys can now be found in:
-    * `cd ../../../config/proxy/ssl-certs`
+        * `cd ../../../config/proxy/ssl-certs`
 
 * Add the SSL .pem and .key file names generated from running the above script to the `./config/proxy/traefik.local.toml` file.
     * `cd ..`
@@ -330,19 +335,19 @@ You can reuse some of the older Production settings in the `local.env` if you li
 ## Step 7: Download the ISLE Images
 
 * Download all of the latest ISLE Docker images (_~6 GB of data may take 5-10 minutes_):
-* _Using the same open terminal_
+* _Using the same open terminal:_
     * Navigate to the root of your ISLE project
     * `cd ~/pathto/yourprojectnamehere`
     * `docker-compose pull`
 
 ## Step 8: Launch Process
 
-* _Using the same open terminal_
+* _Using the same open terminal:_
     * `docker-compose up -d`
 
 * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
 
-* After the above process is completed using the already open terminal or Powershell again.
+* _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
     * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
@@ -357,8 +362,8 @@ You can reuse some of the older Production settings in the `local.env` if you li
     * Host = `127.0.0.1`
     * Port: `3306` _or a different port if you changed it_
     * Username: `root`
-    * Password: `YOUR_MYSQL_ROOT_PASSWORD` in the `local.env`)
-* Select the Drupal database `DRUPAL_DB` in the `local.env`)
+    * Password: `YOUR_MYSQL_ROOT_PASSWORD` in the "local.env")
+* Select the Drupal database `DRUPAL_DB` in the "local.env")
 * Click File > Import (_or equivalent_)
 * Select your exported Production Islandora Drupal database file e.g. `prod_drupal_site_082019.sql.gz`
 * The import process will take 1 -3 minutes depending on the size.
@@ -367,40 +372,53 @@ You can reuse some of the older Production settings in the `local.env` if you li
 
 * Copy the Production Islandora Drupal database file e.g. `prod_drupal_site_082019.sql.gz` to your ISLE MySQL container
     * Run `docker ps` to determine the mysql container name
-    * `docker cp /pathto/prod_drupal_site_082019.sql.gz yourmysql-container-name:/prod_drupal_site_082019.sql.gz`
+    * `docker cp /pathto/prod_drupal_site_082019.sql.gz your-mysql-containername:/prod_drupal_site_082019.sql.gz`
+    * **Example:**
+        * `docker cp /c/db_backups/prod_drupal_site_082019.sql.gz isle-mysql-ld:/prod_drupal_site_082019.sql.gz`
     * This might take a few minutes depending on the size of the file.
 
-* Shell into the mysql container. Replace the `DRUPAL...` below with the values from the `local.env`
-    * `docker exec -it yourmysql-container-name bash`
+* Shell into the mysql container by copying and pasting the appropriate command:
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it your-mysql-containername bash`
+    * **For Microsoft Windows:** `winpty docker exec -it your-mysql-containername bash`
+* Import the Production Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "local.env" file.
     * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < prod_drupal_site_082019.sql.gz`
-    * This might take a few minutes depending on the size of the file.
-    * Exit out of the container when finished.
+* This might take a few minutes depending on the size of the file.
+* Type `exit` to exit the container
 
 ---
 
 ## Step 10: Run Islandora Drupal Site Scripts
 
-You can determine the name of the Apache container by running `docker ps`. make note of the Apache container name, you'll need to use it for the commands below.
+This step will show you how to run the "migration_site_vsets.sh" script on the Apache container to change Drupal database site settings for ISLE connectivity.
 
-* Run the `migration_site_vsets.sh` script on the Apache container. This will change Drupal database site settings only for ISLE connectivity.
-* Copy the `scripts/apache/migration_site_vsets.sh` to the root of the Drupal directory on your Apache container
-    * `docker cp scripts/apache/migration_site_vsets.sh yourapache-container-name:/var/www/html/migration_site_vsets.sh`
+ _Using the same open terminal:_
+ 
+* Run `docker ps` to determine the apache container name
+* Copy the "migration_site_vsets.sh" to the root of the Drupal directory on your Apache container
+    * `docker cp scripts/apache/migration_site_vsets.sh your-apache-containername:/var/www/html/migration_site_vsets.sh`
 * Change the permissions on the script to make it executable
-    * `docker exec -it your-apache-containername chmod +x /var/www/html/migration_site_vsets.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/migration_site_vsets.sh"`
+    * **For Microsoft Windows:** `winpty docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/migration_site_vsets.sh"`
 * Run the script
-    * `docker exec -it your-apache-containername bash /var/www/html/migration_site_vsets.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it your-apache-containername bash -c "cd /var/www/html && ./migration_site_vsets.sh"`
+    * **For Microsoft Windows:** `winpty docker exec -it your-apache-containername bash -c "cd /var/www/html && ./migration_site_vsets.sh"`
 
-* Since you've imported an existing Drupal database, you'll need to reinstall the Islandora solution packs so the Fedora repository will be ready to ingest objects.
-* Copy the `scripts/apache/install_solution_packs.sh` to the root of the Drupal directory on your Apache container
-    * `docker cp scripts/apache/install_solution_packs.sh yourapache-container-name:/var/www/html/install_solution_packs.sh`
+Since you've imported an existing Drupal database, you must now reinstall the Islandora solution packs so the Fedora repository will be ready to ingest objects.
+
+* Copy the "install_solution_packs.sh" to the root of the Drupal directory on your Apache container
+    * **For Mac/Ubuntu/CentOS/etc:** `docker cp scripts/apache/install_solution_packs.sh your-apache-containername:/var/www/html/install_solution_packs.sh`
+    * **For Microsoft Windows:** `winpty docker cp scripts/apache/install_solution_packs.sh your-apache-containername:/var/www/html/install_solution_packs.sh`
 * Change the permissions on the script to make it executable
-    * `docker exec -it your-apache-containername chmod +x /var/www/html/install_solution_packs.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/install_solution_packs.sh"`
+    * **For Microsoft Windows:** `winpty docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/install_solution_packs.sh"`
 * Run the script
-    * `docker exec -it your-apache-containername bash /var/www/html/install_solution_packs.sh`  
-    * This process will take a few minutes depending on the speed of your local and Internet connection.
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it your-apache-containername bash -c "cd /var/www/html && ./install_solution_packs.sh"`
+    * **For Microsoft Windows:** `winpty docker exec -it your-apache-containername bash -c "cd /var/www/html && ./install_solution_packs.sh"`
+* The above process will take a few minutes depending on the speed of your local and Internet connection.
+    * You should see a lot of green [ok] messages.
+    * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
 
-```
-| For Windows Users only |
+| Microsoft Windows |
 | :-------------      |
 | You may be prompted by Windows to: |
 | - Share the C drive with Docker.  Click Okay or Allow.|
@@ -408,11 +426,7 @@ You can determine the name of the Apache container by running `docker ps`. make 
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-
-* You should see a lot of green [ok] messages.
-* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-* **Proceed only after this message appears:** `Clearing Drupal Caches. 'all' cache was cleared.`
-```
+* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
 
 ---
 
@@ -424,25 +438,29 @@ You can determine the name of the Apache container by running `docker ps`. make 
 
 * Note: You may see an SSL error warning that the site is unsafe. It is safe, it simply uses "self-signed" SSL certs. Ignore the error and proceed to the site.
 
-* Log in to the local Islandora site with the credentials you created in `local.env` (`DRUPAL_ADMIN_USER` and `DRUPAL_ADMIN_PASS`)
+* Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "local.env".
 
     * You can also attempt to use login credentials that the Production server would have stored in its database.
     
 * If the newly created Drupal login doesn't work then, you'll need to Shell into the Apache container:
 
-    * `docker exec -it your-apache-containername bash`
-    
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it your-apache-containername bash`
+    * **For Microsoft Windows:** `winpty docker exec -it your-apache-containername bash`
+
+* Navigate to this directory
     * `cd /var/www/html`
     
-    * Create the user found in `DRUPAL_ADMIN_USER` and set its password to the value of `DRUPAL_ADMIN_PASS` as you previously created in `local.env`. In the example below swap-out `DRUPAL_ADMIN_USER` & `DRUPAL_ADMIN_PASS` with those found in `local.env`
-    
-        * `drush user-create DRUPAL_ADMIN_USER --mail="youremailaddresshere" --password="DRUPAL_ADMIN_PASS";`
-        
-        * `drush user-add-role "administrator" DRUPAL_ADMIN_USER`
-        
-    * `exit` the container
+* Create the user found in "DRUPAL_ADMIN_USER" and set its password to the value of "DRUPAL_ADMIN_PASS" as you previously created in "local.env". 
 
-    * Attempt to login again
+    * In the example below swap-out "DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS" with those found in "local.env".
+
+    * `drush user-create DRUPAL_ADMIN_USER --mail="youremailaddresshere" --password="DRUPAL_ADMIN_PASS";`
+    
+    * `drush user-add-role "administrator" DRUPAL_ADMIN_USER`
+    
+* Type `exit` to exit the container
+
+* Attempt to login again
 
 ---
 

--- a/docs/install/install-local-new.md
+++ b/docs/install/install-local-new.md
@@ -1,6 +1,6 @@
 # Local ISLE Installation: New Site
 
-_Expectations:  It takes an average of **60 - 120 minutes** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **60-120 minutes** to read this documentation and complete this installation._
 
 This `Local` ISLE Installation creates an un-themed Drupal website and an empty Fedora repository similar to the `Demo` installation but one that you can use to develop and design your Drupal site and Fedora collections with the end goal of deploying to ISLE Staging and Production environments for public use.
 
@@ -24,30 +24,31 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have access to a private git repository in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc.
     * If you do not, please contact your IT department for git resources, or else create an account with one of the above providers.
-    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files.
-    * **DO NOT** share these git repositories publicly.
+    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files. **DO NOT** share these git repositories publicly.
 
-* For Windows Users only: You must install [Git for Windows](https://gitforwindows.org/) and use its provided Git BASH command line; this behaves more similarly to LINUX and UNIX environments. (Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.) Git for Windows also installs `openssl.exe` which will be needed to generate self-signed SSL certs.
+* **For Microsoft Windows:**
+    * You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git BASH" as your command line interface; this behaves more similarly to LINUX and UNIX environments. Git for Windows also installs `openssl.exe` which will be needed to generate self-signed SSL certs. (Note: Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.)
+    * Set your text editor to use UNIX style line endings for files. (Text files created on DOS/Windows machines have different line endings than files created on Unix/Linux. DOS uses carriage return and line feed ("\r\n") as a line ending, which Unix uses just line feed ("\n").)
 
 ---
 
 ## Index of Instructions
 
-* Step 1: Edit `/etc/hosts` File
-* Step 2: Setup git for the ISLE project
-* Step 3: Edit the `.env` File to change to the Local Environment
-* Step 4: Create new users and passwords by editing `local.env`
-* Step 5: Create new self-signed certs for your project
-* Step 6: Download the ISLE images
+* Step 1: Edit "/etc/hosts" File
+* Step 2: Setup Git for the ISLE Project
+* Step 3: Edit the ".env" File to Point to the Local Environment
+* Step 4: Create New Users and Passwords by Editing "local.env"
+* Step 5: Create New Self-Signed Certs for Your Project
+* Step 6: Download the ISLE Images
 * Step 7: Launch Process
-* Step 8: Run Islandora Drupal site Install Script
+* Step 8: Run Islandora Drupal Site Install Script
 * Step 9: Test the Site
 * Step 10: Ingest Sample Objects
-* Step 11: Check-in the newly created Islandora Drupal site code into a git repository
+* Step 11: Check-In the Newly Created Islandora Drupal Site Code Into a Git Repository
 
 ---
 
-## Step 1: Edit `/etc/hosts` File
+## Step 1: Edit "/etc/hosts" File
 
 Enable the Local ISLE Installation to be viewed locally on personal computer browser as: e.g. `https://yourprojectnamehere.localdomain`.
 
@@ -57,7 +58,7 @@ Enable the Local ISLE Installation to be viewed locally on personal computer bro
 
 ---
 
-## Step 2: Setup git for the ISLE project
+## Step 2: Setup Git for the ISLE Project
 
 **Please note:** The commands given below are for command line usage of git. GUI based clients such as the [SourceTree App](https://www.sourcetreeapp.com/) may be easier for endusers to use for the git process.
 
@@ -72,7 +73,7 @@ The git project name can be your institution name or the name of the collections
 
 Clone this newly created ISLE project to your personal computer
 
-  * Open a `terminal` (Windows: open `PowerShell`)
+  * Open a `terminal` (Windows: open `Git Bash`)
   * Navigate to a directory that will house your new ISLE project directory using the `cd` command.
   * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git`
 
@@ -104,15 +105,15 @@ Pull down the ICG ISLE `master` branch into your local project's `master` branch
 Push this code to your online git provider ISLE
 
   * `git push -u origin master`
-  * This will take 2 - 5 mins depending on your internet speed.
+  * This will take 2-5 mins depending on your internet speed.
 
 Now you have the current ISLE project code checked into git as foundation to make changes on specific to your local and project needs. You'll use this git "icg-upstream" process in the future to pull updates and releases from the main ISLE project.
 
 ---
 
-## Step 3: Edit the `.env` File to change to the Local Environment
+## Step 3: Edit the ".env" File to Point to the Local Environment
 
-Open a `terminal` (Windows: open `PowerShell`)
+Open a `terminal` (Windows: open `Git Bash`)
 
 * Navigate to your ISLE project directory. (You may already be in this directory if you are coming from the [Software Dependencies](../install/host-software-dependencies.md).)
 
@@ -125,7 +126,7 @@ Open a `terminal` (Windows: open `PowerShell`)
     * `CONTAINER_SHORT_ID=ld` _leave default setting of `ld` as is. Do not change._
     * `COMPOSE_FILE=docker-compose.local.yml`
 
-* If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to open up the `3306` port. If you are already running MySQL on your personal computer, you'll have a port conflict either shutdown that service prior to running ISLE or change 3306:3306 to something like `9306:3306`. Please double-check.
+* If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to Open the `3306` port. If you are already running MySQL on your personal computer, you'll have a port conflict either shutdown that service prior to running ISLE or change 3306:3306 to something like `9306:3306`. Please double-check.
 
 * Enter `Cntrl` and the letter `o` together to write the changes to the file.
 
@@ -133,36 +134,37 @@ Open a `terminal` (Windows: open `PowerShell`)
 
 ---
 
-## Step 4: Create new users and passwords by editing `local.env`
+## Step 4: Create New Users and Passwords by Editing "local.env"
 
-* Open up the `local.env` file in a text editor.
+* Open the "local.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open up the `config/apache/settings_php/settings.local.php` file in a text editor.
+* Open the `config/apache/settings_php/settings.local.php` file in a text editor.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
 
 ---
 
-## Step 5: Create new self-signed certs for your project
+## Step 5: Create New Self-Signed Certs for Your Project
 
-* **Mac/Ubuntu/CentOS/Unix** - Open `./scripts/proxy/ssl-certs/local.sh` in a text editor.
-* **For Windows Users only** - Open `./scripts/proxy/ssl-certs/local-windows-only.sh` in a text editor.
-    * Follow the in-line instructions to add your project's name to the appropriate areas.
+* Open the appropriate file in a text editor:
+    * **For Mac/Ubuntu/CentOS/etc:** `./scripts/proxy/ssl-certs/local.sh`
+    * **For Microsoft Windows:** `./scripts/proxy/ssl-certs/local-windows-only.sh`
+* Follow the in-line instructions to add your project's name to the appropriate areas.
     * Once finished, save and close the file.
 
-* _Using the same open terminal_, navigate to `/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
+* _Using the same open terminal:_, navigate to `/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
     * `cd /pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
-    * **Mac/Ubuntu/CentOS/Unix** - `chmod +x local.sh`
-    * **For Windows Users only** - `chmod +x local-windows-only.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** `chmod +x local.sh`
+    * **For Microsoft Windows:** `chmod +x local-windows-only.sh`
 
 * The following command will generate new self-signed SSL keys using your `yourprojectnamehere.localdomain` domain. This now secures the local site.
-    * **Mac/Ubuntu/CentOS/Unix** - `./local.sh`
-    * **For Windows Users only** - `./local-windows-only.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** `./local.sh`
+    * **For Microsoft Windows:** `./local-windows-only.sh`
     * The generated keys can now be found in `./config/proxy/ssl-certs`
 
 * Add the SSL .pem and .key file names generated from running the above script to the `./config/proxy/traefik.local.toml` file.
@@ -172,22 +174,22 @@ Open a `terminal` (Windows: open `PowerShell`)
 
 ---
 
-## Step 6: Download the ISLE images
+## Step 6: Download the ISLE Images
 
 * Download all of the latest ISLE Docker images (_~6 GB of data may take 5-10 minutes_).
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * Navigate to the root of your ISLE project
     * `cd ~/pathto/yourprojectnamehere`
     * `docker-compose pull`
 
 ## Step 7: Launch Process
 
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * `docker-compose up -d`
 
 * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
 
-* After the above process is completed using the already open terminal or Powershell again.
+* _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
     * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
@@ -196,21 +198,21 @@ Open a `terminal` (Windows: open `PowerShell`)
 
 ---
 
-## Step 8: Run Islandora Drupal site Install Script
+## Step 8: Run Islandora Drupal Site Install Script
 
 We highly recommend that you first review the contents of the `docker-compose.local.yml` file as the ISLE Apache service uses bind mounts for the intended Drupal Code instead of using default Docker volumes. This allows users to perform Local Islandora Drupal site development with an IDE. This line is a suggested path and users are free to change values to the left of the `:` to match their Apache data folder of choice. However we recommend starting out with the default setting below.
 Default: `- ./data/apache/html:/var/www/html:cached`
 
 Initially when starting up, end-users will need to run the install script and then ultimately check the resulting Drupal code into a git repository. If you are familiar with that process then Step 9.
 
-This process may take 10 - 20 minutes (_depending on system and internet speeds_)
+* Run the install site script on the Apache container by copying and pasting the appropriate command:
+    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
+    * **For Microsoft Windows:** `winpty docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
+* The above process may take 10-20 minutes (_depending on system and internet speeds_)
+    * You should see a lot of green [ok] messages.
+    * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
 
-* Run the install site script on the Apache container by copying and pasting this command:
-```
-docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh
-```
-
-| For Windows Users only |
+| Microsoft Windows |
 | :-------------      |
 | You may be prompted by Windows to: |
 | - Share the C drive with Docker.  Click Okay or Allow.|
@@ -218,9 +220,7 @@ docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isl
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* You should see a lot of green [ok] messages.
-* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-* **Proceed only after this message appears:** `Clearing Drupal Caches. 'all' cache was cleared.`
+* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
 
 ---
 
@@ -229,7 +229,7 @@ docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isl
 * In your web browser, enter this URL: `https://yourprojectnamehere.localdomain`
 <!--- TODO: Add error message and how to proceed (click 'Advanced...') --->
 * Note: You may see an SSL error warning that the site is unsafe. It is safe, it simply uses "self-signed" SSL certs. Ignore the error and proceed to the site.
-* Log in to the local Islandora site with the credentials you created in `local.env` (`DRUPAL_ADMIN_USER` and `DRUPAL_ADMIN_PASS`)
+* Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "local.env".
 
 ---
 
@@ -250,9 +250,9 @@ git clone https://github.com/Islandora-Collaboration-Group/islandora-sample-obje
     * Click: `Save Blocks` at bottom of page
     * You may now search for ingested objects that have been indexed by SOLR
 
-## Step 11: Check-in the newly created Islandora Drupal site code into a git repository
+## Step 11: Check-In the Newly Created Islandora Drupal Site Code Into a Git Repository
 
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
 
 * Navigate to the `data` directory within your local ISLE project
     * `cd data/apache/html`
@@ -268,7 +268,7 @@ git clone https://github.com/Islandora-Collaboration-Group/islandora-sample-obje
     * `git commit -m "Setting up Drupal site"`
 
 * Add the git `remote` (this will be remote / cloud based git repository that you'll push changes to). This can be Bitbucket, Github or Gitlab.
-    * For example: `git remote add origin https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
+    * **Example:** `git remote add origin https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
 
 * Push the changes to the remote git repository on the `master` branch
     * `git push -u origin master`

--- a/docs/install/install-local-resources.md
+++ b/docs/install/install-local-resources.md
@@ -7,7 +7,7 @@ Always use the `https://yourprojectnamehere.localdomain` domain to view and log 
 
 ### Docker Containers: Passwords
 
-As instructed in the `## Step 4: Create new users and passwords by editing local.env` section of the [Local ISLE Installation: New Site](../install/install-local-new.md) documentation, you'll need to refer to the edited `local.env` for your password choices.
+As instructed in the `## Step 4: Create New Users and Passwords by Editing "local.env"` section of the [Local ISLE Installation: New Site](../install/install-local-new.md) documentation, you'll need to refer to the edited `local.env` for your password choices.
 
 * `islandora` user on the ISLE host server uses `islandora` as the password. This might not apply to your setup if using local Docker clients.
 

--- a/docs/install/install-production-migrate.md
+++ b/docs/install/install-production-migrate.md
@@ -1,6 +1,6 @@
 # Production ISLE Installation: Migrate Existing Islandora Site
 
-_Expectations:  It takes an average of **2 - 4+ hours** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
 This `Production` ISLE Installation will be similar to the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions you just followed but in addition to using a copy of your currently running Production themed Drupal website, a copy of the Production Fedora repository will also be needed for you to continue migrating to ISLE with the end goal of first deploying to an ISLE Production environment and then cut over from the existing non-ISLE Production and Production servers to their new ISLE counterparts.
 
@@ -47,8 +47,7 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have access to a private git repository in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc.
     * If you do not, please contact your IT department for git resources, or else create an account with one of the above providers.
-    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files.
-    * **DO NOT** share these git repositories publicly.
+    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files. **DO NOT** share these git repositories publicly.
 
 * You have already have the appropriate A record entered into your institutions DNS system and can resolve the Production domain (https://yourprojectnamehere.institution.edu) using a tool like https://www.whatsmydns.net/
 
@@ -58,7 +57,7 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
     * When ready to launch the new ISLE production site publicly, you can remove the `-newprod` from all domain references and configuration files.
         * Update the DNS records to repoint the current non-ISLE Production server A record for `yourprojectnamehere.institution.edu` to the new ISLE host server IP.
         * Remove the temporary DNS A record for `yourprojectnamehere-newprod.institution.edu`
-        * If using Commercial SSLs, you'll also need to copy them over to the `./config/proxy/ssl-certs` directory and adjust the `traefik.production.toml` file accordingly with the new file names.
+        * If using commercial SSLs, you'll also need to copy them over to the `./config/proxy/ssl-certs` directory and adjust the `traefik.production.toml` file accordingly with the new file names.
 
 * You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested `Production` values.
 
@@ -76,36 +75,36 @@ This process will differ slightly from previous builds in that there is work to 
 
 The instructions that follow below will have either a `On Local` or a `On Remote Production` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Production` and for future ISLE updates and upgrades.
 
-**Steps 1 - 6** - `On Local - Configure the ISLE Production environment profile for deploy to Remote`
+**Steps 1-6: On Local - Configure the ISLE Production Environment Profile for Deploy to Remote**
 
-  * Step 1: Copy Production data to your local
-  * Step 2: On Local - Shutdown any local containers & review local code
-  * Step 3: On Local - Create new users and passwords by editing `production.env`
-  * Step 4: On Local - Review and edit docker-compose.production.yml
-  * Step 4A: On Local - (Optional) changes for docker-compose.production.yml
-  * Step 5: On Local Production - If using Commercial SSLs
-  * Step 6: On Local - Commit ISLE code to git repository
+  * Step 1: Copy Production Data to Your Local
+  * Step 2: On Local - Shutdown Any Local Containers & Review Local Code
+  * Step 3: On Local - Create New Users and Passwords by Editing "production.env"
+  * Step 4: On Local - Review and Edit "docker-compose.production.yml"
+  * Step 4A: On Local - (Optional) Changes for "docker-compose.production.yml"
+  * Step 5: On Local Production - If Using Commercial SSLs
+  * Step 6: On Local - Commit ISLE Code to Git Repository
 
-**Steps 7 - 18**   - `On Remote Production - Configure the ISLE Production environment profile for launch and usage`
+**Steps 7-18: On Remote Production - Configure the ISLE Production Environment Profile for Launch and Usage**
 
-  * Step 7: On Remote Production - Git clone the ISLE repository to the remote Production ISLE host server
-  * Step 8: On Remote Production - Create the appropriate local data paths for Apache, Fedora and log data
-  * Step 9: On Remote Production - Clone your Production Islandora code
-  * Step 10: On Remote Production - Copy over the Production Data directories
-  * Step 11: On Remote Production - If using Let's Encrypt
-  * Step 12: On Remote Production - Edit the .env file to change to the Production environment
-  * Step 13: On Remote Production - Download the ISLE images
+  * Step 7: On Remote Production - Git Clone the ISLE Repository to the Remote Production ISLE Host Server
+  * Step 8: On Remote Production - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
+  * Step 9: On Remote Production - Clone Your Production Islandora Code
+  * Step 10: On Remote Production - Copy Over the Production Data Directories
+  * Step 11: On Remote Production - If Using Let's Encrypt
+  * Step 12: On Remote Production - Edit the ".env" File to Change to the Production Environment
+  * Step 13: On Remote Production - Download the ISLE Images
   * Step 14: On Remote Production - Start Containers
-  * Step 15: On Remote Production - Import the Production MySQL Drupal database
-  * Step 16: On Remote Production - Run ISLE scripts
-  * Step 17: On Remote Production - Re-index Fedora & Solr
-  * Step 18: On Remote Production - Review and test the Drupal Production site
+  * Step 15: On Remote Production - Import the Production MySQL Drupal Database
+  * Step 16: On Remote Production - Run ISLE Scripts
+  * Step 17: On Remote Production - Re-Index Fedora & Solr
+  * Step 18: On Remote Production - Review and Test the Drupal Production Site
 
 ---
 
-## Step 1: Copy Production data to your local
+## Step 1: Copy Production Data to Your Local
 
-### Drupal site database
+### Drupal Site Database
 
 You are repeating this step given that data may have changed on the Production site since creating your local. It is critical that Production be a mirror or close to exact copy of Production.
 
@@ -121,7 +120,7 @@ You are repeating this step given that data may have changed on the Production s
 
 * If possible, on the production Apache webserver, run `drush cc all` from the command line on the production server in the `/var/www/html` directory PRIOR to any db export(s). Otherwise issues can occur on import due to all cache tables being larger than `innodb_log_file_size` allows
 
-#### Production Islandora Drupal site database export process
+#### Export the Production MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current Production Islandora Drupal site in use and copy it to your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your Production site. If you are not comfortable or familiar with performing these actions, we recommend that you instead work with your available IT resources to do so.
     * You can use a MySQL GUI client for this process or if you have command line access to the MySQL database server
@@ -130,33 +129,33 @@ You are repeating this step given that data may have changed on the Production s
 
 ---
 
-## Step 2: On Local - Shutdown any local containers & review local code
+## Step 2: On Local - Shutdown Any Local Containers & Review Local Code
 
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
-* Once finished, open a `terminal` (Windows: open `PowerShell`)
+* Once finished, open a `terminal` (Windows: open `Git Bash`)
     * Navigate to your local ISLE directory
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
 
-## Step 3: On Local - Create new users and passwords by editing `production.env`
+## Step 3: On Local - Create New Users and Passwords by Editing "production.env"
 
-* Open up the `production.env` file in a text editor.
+* Open the "production.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
         * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Production` environment but we strongly recommend not reusing all passwords for environments (e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment).
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open up the `config/apache/settings_php/settings.production.php` file.
+* Open the `config/apache/settings_php/settings.production.php` file.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
 
 ---
 
-## Step 4: On Local - Review and edit docker-compose.production.yml
+## Step 4: On Local - Review and Edit "docker-compose.production.yml"
 
 * Review the disks and volumes on your remote `Production` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.production.yml` file.
 
@@ -169,7 +168,7 @@ You are repeating this step given that data may have changed on the Production s
 
 * Review the your `docker-compose.local.yml` file for custom edits made and copy them to the `docker-compose.production.yml` file as needed, this can include changes to Fedora Gsearch Transforms, Fedora hash size and more.
 
-### SSL certificates
+### SSL Certificates
 
 * Depending on your choice of SSL type (Commercial SSL files or the Let's Encrypt service), you'll need to uncomment only one line of the `traefik` services section. There are also inline instructions to this effect in the `docker-compose.production.yml` file.
     * To use `Let's Encrypt for SSL`, uncomment:
@@ -183,7 +182,7 @@ You are repeating this step given that data may have changed on the Production s
 
 ---
 
-## Step 4A: On Local - (Optional) changes for  docker-compose.production.yml
+## Step 4A: On Local - (Optional) Changes for "docker-compose.production.yml"
 
 This section is for optional changes for the `docker-compose.production.yml`, end-users do not have feel like they have to make any choices here and can continue to **Step 4** as needed.
 
@@ -216,7 +215,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 ---
 
-## Step 5: On Local Production - If using Commercial SSLs
+## Step 5: On Local Production - If Using Commercial SSLs
 
 If you are going to use Let's Encrypt instead, you can skip this step and move onto the next one. There will be additional steps further in this document, to help you configure it.
 
@@ -249,7 +248,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## Step 6: On Local - Commit ISLE code to git repository
+## Step 6: On Local - Commit ISLE Code to Git Repository
 
 * Once you have made all of the appropriate changes to your `Production` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
@@ -258,9 +257,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## On Remote Production - Configure the ISLE Production environment profile for launch and usage
+## On Remote Production - Configure the ISLE Production Environment Profile for Launch and Usage
 
-## Step 7: On Remote Production - Git clone the ISLE repository to the remote Production ISLE host server
+## Step 7: On Remote Production - Git Clone the ISLE Repository to the Remote Production ISLE Host Server
 
 * This assumes you have setup an `Islandora` deploy user. If not use a different non-root user for this purpose.
 
@@ -272,7 +271,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 * Clone your ISLE project repository with the newly committed changes for `Production` to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
-    * This may take a few minutes (2 - 4) depending on your server's Internet connection.
+    * This may take a few minutes (2-4) depending on your server's Internet connection.
 
 * Move the newly cloned directory to the `/opt` directory as the root user
     * `sudo mv /home/islandora/yourprojectnamehere-isle /opt/yourprojectnamehere-isle`
@@ -282,7 +281,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 8: On Remote Production - Create the appropriate local data paths for Apache, Fedora and log data
+## Step 8: On Remote Production - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
 
 * Create the `/opt/data` directory
     * `sudo mkdir -p /opt/data`
@@ -291,7 +290,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 9: On Remote Production - Clone your Production Islandora code
+## Step 9: On Remote Production - Clone Your Production Islandora Code
 
 Please clone from your existing Production Islandora git repository.
 
@@ -302,11 +301,11 @@ Please clone from your existing Production Islandora git repository.
 
 ---
 
-## Step 10: On Remote Production - Copy over the Production Data directories
+## Step 10: On Remote Production - Copy Over the Production Data Directories
 
 * It is recommended that you schedule a content freeze for all Production Fedora ingests and additions to your Production website. This will allow you to get up to date data from Production to Production.
 
-* As you may have made some critical decisions potentially from `Step 0: Copy Production data to your local` of the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions, you need to re-follow the steps to get your:
+* As you may have made some critical decisions potentially from "Step 0: Copy Production Data to Your Local" of the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions, you need to re-follow the steps to get your:
     * `Production` Drupal site `files` directory
     * `Solr schema & Islandora transforms`
         * If you picked **Easy** option:
@@ -323,7 +322,7 @@ Please clone from your existing Production Islandora git repository.
 
 ---
 
-## Step 11: On Remote Production - If using Let's Encrypt
+## Step 11: On Remote Production - If Using Let's Encrypt
 
 If you are using Commercial SSLs, then please stop and move onto the next step.
 
@@ -338,7 +337,7 @@ If using Let's Encrypt, please continue to follow this step.
 
 ---
 
-## Step 12: On Remote Production - Edit the .env file to change to the Production environment
+## Step 12: On Remote Production - Edit the ".env" File to Change to the Production Environment
 
 This step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit that never gets pushed back to the git repository is critical to allow future ISLE updates or config changes.
 
@@ -404,10 +403,10 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 ---
 
-## Step 13: On Remote Production - Download the ISLE images
+## Step 13: On Remote Production - Download the ISLE Images
 
 * Download all of the latest ISLE Docker images (_~6 GB of data may take 5-10 minutes_).
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * Navigate to the root of your ISLE project
     * `cd ~/opt/yourprojectnamehere`
     * `docker-compose pull`
@@ -418,12 +417,12 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 **Please note:** Prior to starting the launch process, it is recommended that you briefly open your firewall to allow ports 80 and 443 access to the world. You'll only need to keep this open for 3 -5 minutes and then promptly close access once the Let's Encrypt SSL certificates have been generated.
 
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * `docker-compose up -d`
 
 * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
 
-* After the above process is completed using the already open terminal or Powershell again.
+* _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
     * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
@@ -435,7 +434,7 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 ---
 
-## Step 15: On Remote Production - Import the Local MySQL Drupal database
+## Step 15: On Remote Production - Import the Local MySQL Drupal Database
 
 **Prior to attempting this step, please consider the following:**
 
@@ -445,48 +444,48 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 ---
 
-### Local Islandora Drupal site database import process
+### Import the Local MySQL Islandora Drupal Database
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Production server.
 
 * Import the exported `Local` MySQL database for use in the current `Production` Drupal site. Refer to your `production.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
-    * _Using the same open terminal / Powershell_  
-    * Shell into your currently running `Production` MySQL container
-        * `docker exec -it yourmysql-container-name bash`
-    * Import the Local Islandora Drupal database. Replace the `DRUPAL_DB` & `DRUPAL_DB_USER` below in the command with the values found in your `production.env`.
+    * _Using the same open terminal:_  
+    * Shell into your currently running "Production" MySQL container
+        * `docker exec -it your-mysql-containername bash`
+    * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "production.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
-        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the `production.env`)
+        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the "production.env")
         * This might take a few minutes depending on the size of the file.
-        * Exit out of the container when finished.
+        * Type `exit` to exit the container
 
 ---
 
-## Step 16: On Remote Production - Run ISLE scripts
+## Step 16: On Remote Production - Run ISLE Scripts
 
-You can determine the name of the Apache container by running `docker ps`. make note of the Apache container name, you'll need to use it for the commands below.
+This step will show you how to run the "migration_site_vsets.sh" script on the Apache container to change Drupal database site settings for ISLE connectivity.
 
-### Run migration_site_vsets.sh script on the Apache container
+ _Using the same open terminal:_  
 
-* _Using the same open terminal / Powershell_
-    * Run the `migration_site_vsets.sh` script on the Apache container. This will change Drupal database site settings only for ISLE connectivity.
-    * Copy the `./scripts/apache/migration_site_vsets.sh` to the root of the Drupal directory on your Apache container
-        * `docker cp ./scripts/apache/migration_site_vsets.sh yourapache-container-name:/var/www/html/migration_site_vsets.sh`
-    * Change the permissions on the script to make it executable
-        * `docker exec -it your-apache-containername chmod +x /var/www/html/migration_site_vsets.sh`
-    * Run the script
-        * `docker exec -it your-apache-containername bash /var/www/html/migration_site_vsets.sh`
+* Run `docker ps` to determine the apache container name
+* Copy the "migration_site_vsets.sh" to the root of the Drupal directory on your Apache container
+    * `docker cp ./scripts/apache/migration_site_vsets.sh your-apache-containername:/var/www/html/migration_site_vsets.sh`
+* Change the permissions on the script to make it executable
+    * `docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/migration_site_vsets.sh"`
+* Run the script
+    * `docker exec -it your-apache-containername bash -c "cd /var/www/html && ./migration_site_vsets.sh"`
 
-### Run fix-permissions.sh script on the Apache container
-* You'll need to fix the Drupal site permissions by running the `/fix-permissions.sh` script from the Apache container
-* Shell into your currently running `Production` Apache container
-    * `docker exec -it yourapache-container-name bash`
-    * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
-    * This process will take 2 - 5 mins depending
-    * Type `exit` to exit the container
+This step will show you how to shell into your currently running "Production" Apache container, and run the "fix-permissions.sh" script to fix the Drupal site permissions.
 
-| For Windows Users only |
+* `docker exec -it your-apache-containername bash`
+* `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
+* This process will take 2-5 minutes
+* You should see a lot of green [ok] messages.
+* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
+* Type `exit` to exit the container
+
+| Microsoft Windows |
 | :-------------      |
 | You may be prompted by Windows to: |
 | - Share the C drive with Docker.  Click Okay or Allow.|
@@ -494,11 +493,9 @@ You can determine the name of the Apache container by running `docker ps`. make 
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-
 ---
 
-## Step 17: On Remote Production - Re-index Fedora & Solr
+## Step 17: On Remote Production - Re-Index Fedora & Solr
 
 When migrating any non-ISLE Islandora site, it is crucial to rebuild (reindex) the following three indices from the FOXML and datastream files on disk.
 
@@ -518,9 +515,9 @@ Since this command can take minutes or hours depending on the size of your repos
 
 **Please note:** The method described below is a longer way of doing this process to onboard users.
 
-* Shell into your currently running `Production` Fedora container
+* Shell into your currently running "Production" Fedora container
 * Run `docker ps` to determine the Fedora container name
-    * `docker exec -it yourfedora-container-name bash`
+    * `docker exec -it your-fedora-containername bash`
 
 * Navigate to the `utility_scripts` directory
     * `cd utility_scripts`
@@ -555,7 +552,7 @@ OK - Started application at context path [/fedora]
 
 ### Reindex Solr (3/3)
 
-**WARNING** - This reindex process takes the longest of all three, with up to **1 - 30 or more hours** to complete depending on the size of your Fedora collection. As such, it is recommended starting a screen session prior to running the following command. Learn more about [screen here](https://www.tecmint.com/screen-command-examples-to-manage-linux-terminals/)
+**WARNING** - This reindex process takes the longest of all three, with up to **1-30 or more hours** to complete depending on the size of your Fedora collection. As such, it is recommended starting a screen session prior to running the following command. Learn more about [screen here](https://www.tecmint.com/screen-command-examples-to-manage-linux-terminals/)
 
 * Still staying within the `utility_scripts` directory on the Fedora container or reenter the Fedora container having started a new screen session, now run the `updateSolrIndex.sh` script. This script will give you output like the example below.
     * `./updateSolrIndex.sh`
@@ -588,12 +585,12 @@ Args
 
 ---
 
-## Step 18: On Remote Production - Review and test the Drupal Production site
+## Step 18: On Remote Production - Review and Test the Drupal Production Site
 
 * In your web browser, enter this URL: `https://yourprojectnamehere.institution.edu`
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
-* Log in to the local Islandora site with the credentials you created in `production.env` (`DRUPAL_ADMIN_USER` and `DRUPAL_ADMIN_PASS`)
+* Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "production.env".
     * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.
@@ -606,7 +603,7 @@ Args
 Once you are ready to deploy your finished Drupal site, you may progress to launching the Production site publicly which could involve the following steps depending on choices made earlier in this document and process:
 
 * If you followed the use of the temporary `-newprod` suggestion in the `Assumptions` section, remove the `-newprod` from all domain references and configuration files and recommit the change on the remote server in git.
-    * If using Commercial SSLs, you'll also need to copy them over to the `./config/proxy/ssl-certs` directory and adjust the `traefik.production.toml` file accordingly with the new file names.
+    * If using commercial SSLs, you'll also need to copy them over to the `./config/proxy/ssl-certs` directory and adjust the `traefik.production.toml` file accordingly with the new file names.
     * If using Let's Encrypt, upon restart with the new settings, the acme.json file contents will change automatically.
     * Update the DNS records to repoint the current non-ISLE Production server A record for `yourprojectnamehere.institution.edu` to the new ISLE host server IP.
     * Remove the temporary DNS A record for `yourprojectnamehere-newprod.institution.edu`

--- a/docs/install/install-production-new.md
+++ b/docs/install/install-production-new.md
@@ -1,6 +1,6 @@
 # Production ISLE Installation: New Site
 
-_Expectations:  It takes an average of **2 - 4+ hours** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
 This `Production` ISLE Installation will use the themed Drupal website created during the [Local ISLE Installation: New Site](../install/install-local-new.md) process and will create an empty Fedora repository for remote (non-local / cloud) hosting of a `Production` site. Islandora Drupal site code here should be considered finished and ready for public access. The previously used `Production` system might have Fedora data & collections that should then be synced to this `Production` site or endusers can choose to only ingest on `Production`. It is recommended that this remote site not be publicly accessible until ready to launch.
 
@@ -35,7 +35,7 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
         * [Hardware Requirements](host-hardware-requirements.md)
         * [Software Dependencies](host-software-dependencies.md)
     * This server should be running at the time of deploy.
-    * This server has enough disk space to store a large Fedora repository e.g. 1 - 5 TB or larger depending on how many objects you plan on ingesting.  
+    * This server has enough disk space to store a large Fedora repository e.g. 1-5 TB or larger depending on how many objects you plan on ingesting.  
 
 * You have already created the two private git repositories for your projects ISLE and Islandora code in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc. having followed Step 2 from the [Local ISLE Installation: New Site](../install/install-local-new.md) instructions. You will continue to use these two git repositories for all environments.
 
@@ -56,36 +56,36 @@ This process will differ slightly from previous builds in that there is work to 
 
 The instructions that follow below will have either a `On Local` or a `On Remote Production` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Production` and for future ISLE updates and upgrades.
 
-**Steps 1 - 6** - `On Local - Configure the ISLE Production environment profile for deploy to Remote`
+**Steps 1-6: On Local - Configure the ISLE Production Environment Profile for Deploy to Remote**
 
-  * Step 1: On Local - Export the Local MySQL database
-      * Local Islandora Drupal site database export process
-  * Step 2: On Local - Shutdown any local containers & review local code
-  * Step 3: On Local - Create new users and passwords by editing `production.env`
-  * Step 4: On Local - Review and edit docker-compose.production.yml
-  * Step 4A: On Local - (Optional) changes for docker-compose.production.yml
-  * Step 5: On Local Production - If using Commercial SSLs
-  * Step 6: On Local - Commit ISLE code to git repository
+  * Step 1: On Local - Export the Local MySQL Database
+        * Export the Local MySQL Islandora Drupal Database
+  * Step 2: On Local - Shutdown Any Local Containers & Review Local Code
+  * Step 3: On Local - Create New Users and Passwords by Editing "production.env"
+  * Step 4: On Local - Review and Edit "docker-compose.production.yml"
+  * Step 4A: On Local - (Optional) Changes for "docker-compose.production.yml"
+  * Step 5: On Local Production - If Using Commercial SSLs
+  * Step 6: On Local - Commit ISLE Code to Git Repository
 
-**Steps 7 - 17**   - `On Remote Production - Configure the ISLE Production environment profile for launch and usage`
+**Steps 7-17: On Remote Production - Configure the ISLE Production Environment Profile for Launch and Usage**
 
-  * Step 7: On Remote Production - Git clone the ISLE repository to the remote Production ISLE host server
-  * Step 8: On Remote Production - Create the appropriate local data paths for Apache, Fedora and log data
-  * Step 9: On Remote Production - Clone your Islandora code
-  * Step 10: On Remote Production - Copy over the Local Islandora Drupal files directory
-  * Step 11: On Remote Production - If using Let's Encrypt
-  * Step 12: On Remote Production - Edit the .env file to change to the Production environment
-  * Step 13: On Remote Production - Download the ISLE images
+  * Step 7: On Remote Production - Git Clone the ISLE Repository to the Remote Production ISLE Host Server
+  * Step 8: On Remote Production - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
+  * Step 9: On Remote Production - Clone Your Islandora Code
+  * Step 10: On Remote Production - Copy Over the Local Islandora Drupal Files Directory
+  * Step 11: On Remote Production - If Using Let's Encrypt
+  * Step 12: On Remote Production - Edit the ".env" File to Change to the Production Environment
+  * Step 13: On Remote Production - Download the ISLE Images
   * Step 14: On Remote Production - Start Containers
-  * Step 15: On Remote Production - Import the Local MySQL Drupal database
-  * Step 16: On Remote Production - Run the fix-permissions.sh script
-  * Step 17: On Remote Production - Review and test the Drupal Production site
+  * Step 15: On Remote Production - Import the Local MySQL Drupal Database
+  * Step 16: On Remote Production - Run the "fix-permissions.sh" Script
+  * Step 17: On Remote Production - Review and Test the Drupal Production Site
 
 ---
 
 ## On Local - Configure the ISLE Production environment profile for deploy to Remote
 
-## Step 1: On Local - Export the Local MySQL database
+## Step 1: On Local - Export the Local MySQL Database
 
 **Prior to attempting this step, please consider the following:**
 
@@ -95,48 +95,48 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 * If possible, on the production Apache webserver, run `drush cc all` from the command line on the local Apache container in the `/var/www/html` directory PRIOR to any db export(s). Otherwise issues can occur on import due to all cache tables being larger than `innodb_log_file_size` allows
 
-### Local Islandora Drupal site database export process
+### Export the Local MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current `Local` Drupal site in use and copy it on your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your newly created and themed new Islandora site. Refer to your `local.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Shell into your currently running Local MySQL container
-        * `docker exec -it yourmysql-container-name bash`
-    * Export the Local Islandora Drupal database. Replace the `DRUPAL_DB` & `DRUPAL_DB_USER` below in the command with the values found in your `local.env`.
+        * `docker exec -it your-mysql-containername bash`
+    * Export the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "local.env" file.
         * `mysqldump -u DRUPAL_DB_USER -p DRUPAL_DB > local_drupal_site_082019.sql`
-        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the `local.env`)
+        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the "local.env")
         * Upon completion, exit the MySQL container  
     * Copy this file from the MySQL container to a location on your personal computer.
-        * `docker cp yourmysql-container-name:/local_drupal_site_082019.sql /path/to/location`
+        * `docker cp your-mysql-containername:/local_drupal_site_082019.sql /path/to/location`
 
 ---
 
-## Step 2: On Local - Shutdown any local containers & review local code
+## Step 2: On Local - Shutdown Any Local Containers & Review Local Code
 
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
-* Once finished, open a `terminal` (Windows: open `PowerShell`)
+* Once finished, open a `terminal` (Windows: open `Git Bash`)
     * Navigate to your local ISLE directory
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
 
-## Step 3: On Local - Create new users and passwords by editing production.env
+## Step 3: On Local - Create New Users and Passwords by Editing "production.env"
 
-* Open up the `production.env` file in a text editor.
+* Open the "production.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
         * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Production` environment but we strongly recommend not reusing all passwords for environments (e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment).
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open up the `config/apache/settings_php/settings.production.php` file.
+* Open the `config/apache/settings_php/settings.production.php` file.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
 
 ---
 
-## Step 4: On Local - Review and edit docker-compose.production.yml
+## Step 4: On Local - Review and Edit "docker-compose.production.yml"
 
 * Review the disks and volumes on your remote `Production` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.production.yml` file.
 
@@ -157,7 +157,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 * Based on the choice of SSL type made above, you'll need to refer to to the `./config/proxy/traefik.production.toml` file for further configuration instructions.
 
-## Step 4A: On Local - (Optional) changes for docker-compose.production.yml
+## Step 4A: On Local - (Optional) Changes for "docker-compose.production.yml"
 
 This section is for optional changes for the `docker-compose.production.yml`, end-users do not have feel like they have to make any choices here and can continue to **Step 4** as needed.
 
@@ -189,7 +189,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 ---
 
-## Step 5: On Local Production - If using Commercial SSLs
+## Step 5: On Local Production - If Using Commercial SSLs
 
 If you are going to use Let's Encrypt instead, you can skip this step and move onto the next one. There will be additional steps further in this document, to help you configure it.
 
@@ -222,7 +222,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## Step 6: On Local - Commit ISLE code to git repository
+## Step 6: On Local - Commit ISLE Code to Git Repository
 
 * Once you have made all of the appropriate changes to your `Production` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
@@ -231,9 +231,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## On Remote Production - Configure the ISLE Production environment profile for launch and usage
+## On Remote Production - Configure the ISLE Production Environment Profile for Launch and Usage
 
-## Step 7: On Remote Production - Git clone the ISLE repository to the remote Production ISLE host server
+## Step 7: On Remote Production - Git Clone the ISLE Repository to the Remote Production ISLE Host Server
 
 * This assumes you have setup an `Islandora` deploy user. If not use a different non-root user for this purpose.
 
@@ -245,7 +245,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 * Clone your ISLE project repository with the newly committed changes for `Production` to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
-    * This may take a few minutes (2 - 4) depending on your server's Internet connection.
+    * This may take a few minutes (2-4) depending on your server's Internet connection.
 
 * Move the newly cloned directory to the `/opt` directory as the root user
     * `sudo mv /home/islandora/yourprojectnamehere-isle /opt/yourprojectnamehere-isle`
@@ -255,7 +255,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 8: On Remote Production - Create the appropriate local data paths for Apache, Fedora and log data
+## Step 8: On Remote Production - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
 
 * Create the `/opt/data` directory
     * `sudo mkdir -p /opt/data`
@@ -264,7 +264,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 9: On Remote Production - Clone your Islandora code
+## Step 9: On Remote Production - Clone Your Islandora Code
 
 * `git clone git@yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git /opt/data/apache/html`
 
@@ -273,7 +273,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 10: On Remote Production - Copy over the Local Islandora Drupal files directory
+## Step 10: On Remote Production - Copy Over the Local Islandora Drupal Files Directory
 
 This `files` directory should be on your personal computer and should be copied to the remote Production server.
 
@@ -284,7 +284,7 @@ This `files` directory should be on your personal computer and should be copied 
 
 ---
 
-## Step 11: On Remote Production - If using Let's Encrypt
+## Step 11: On Remote Production - If Using Let's Encrypt
 
 If you are using Commercial SSLs, then please stop and move onto the next step.
 
@@ -299,7 +299,7 @@ If using Let's Encrypt, please continue to follow this step.
 
 ---
 
-## Step 12: On Remote Production - Edit the .env file to change to the Production environment
+## Step 12: On Remote Production - Edit the ".env" File to Change to the Production Environment
 
 This step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit that never gets pushed back to the git repository is critical to allow future ISLE updates or config changes.
 
@@ -365,10 +365,10 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 ---
 
-## Step 13: On Remote Production - Download the ISLE images
+## Step 13: On Remote Production - Download the ISLE Images
 
 * Download all of the latest ISLE Docker images (_~6 GB of data may take 5-10 minutes_):
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
       * Navigate to the root of your ISLE project
       * `cd ~/opt/yourprojectnamehere`
       * `docker-compose pull`
@@ -379,12 +379,12 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 **Please note:** Prior to starting the launch process, it is recommended that you briefly open your firewall to allow ports 80 and 443 access to the world. You'll only need to keep this open for 3 -5 minutes and then promptly close access once the Let's Encrypt SSL certificates have been generated.
 
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * `docker-compose up -d`
 
 * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
 
-* After the above process is completed using the already open terminal or Powershell again.
+* _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
     * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
@@ -396,7 +396,7 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 ---
 
-## Step 15: On Remote Production - Import the Local MySQL Drupal database
+## Step 15: On Remote Production - Import the Local MySQL Drupal Database
 
 **Prior to attempting this step, please consider the following:**
 
@@ -406,33 +406,35 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 ---
 
-### Local Islandora Drupal site database import process
+### Import the Local MySQL Islandora Drupal Database
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Production server.
 
 * Import the exported `Local` MySQL database for use in the current `Production` Drupal site. Refer to your `production.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
-    * Shell into your currently running `Production` MySQL container
-        * `docker exec -it yourmysql-container-name bash`
-    * Import the Local Islandora Drupal database. Replace the `DRUPAL_DB` & `DRUPAL_DB_USER` below in the command with the values found in your `production.env`.
+    * Shell into your currently running "Production" MySQL container
+        * `docker exec -it your-mysql-containername bash`
+    * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "production.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
-        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the `production.env`)
+        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the "production.env")
         * This might take a few minutes depending on the size of the file.
-        * Exit out of the container when finished.
+        * Type `exit` to exit the container
 
 ---
 
-## Step 16: On Remote Production - Run the fix-permissions.sh script
+## Step 16: On Remote Production - Run the "fix-permissions.sh" Script
 
 * You'll need to fix the Drupal site permissions by running the `/fix-permissions.sh` script from the Apache container
     * Run `docker ps` to determine the Apache container name
-    * Shell into your currently running `Production` Apache container
-        * `docker exec -it yourapache-container-name bash`
+    * Shell into your currently running "Production" Apache container
+        * `docker exec -it your-apache-containername bash`
         * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
-        * This process will take 2 - 5 mins depending
+        * This process will take 2-5 minutes
+        * You should see a lot of green [ok] messages.
+        * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
 
-| For Windows Users only |
+| Microsoft Windows |
 | :-------------      |
 | You may be prompted by Windows to: |
 | - Share the C drive with Docker.  Click Okay or Allow.|
@@ -440,18 +442,16 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* You should see a lot of green [ok] messages.
-* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-* **Proceed only after this message appears:** `Clearing Drupal Caches. 'all' cache was cleared.`
+* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
 
 ---
 
-## Step 17: On Remote Production - Review and test the Drupal Production site
+## Step 17: On Remote Production - Review and Test the Drupal Production Site
 
 * In your web browser, enter this URL: `https://yourprojectnamehere.institution.edu`
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
-* Log in to the local Islandora site with the credentials you created in `production.env` (`DRUPAL_ADMIN_USER` and `DRUPAL_ADMIN_PASS`)
+* Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "production.env".
     * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.

--- a/docs/install/install-staging-migrate.md
+++ b/docs/install/install-staging-migrate.md
@@ -1,6 +1,6 @@
 # Staging ISLE Installation: Migrate Existing Islandora Site
 
-_Expectations:  It takes an average of **2 - 4+ hours** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
 This `Staging` ISLE Installation will be similar to the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions you just followed but in addition to using a copy of your currently running Production themed Drupal website, a copy of the Production Fedora repository will also be needed for you to continue migrating to ISLE with the end goal of first deploying to an ISLE Production environment and then cut over from the existing non-ISLE Production and Staging servers to their new ISLE counterparts.
 
@@ -53,8 +53,7 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have access to a private git repository in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc.
     * If you do not, please contact your IT department for git resources, or else create an account with one of the above providers.
-    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files.
-    * **DO NOT** share these git repositories publicly.
+    * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files. **DO NOT** share these git repositories publicly.
 
 * You have already have the appropriate A record entered into your institutions DNS system and can resolve the Staging domain (https://yourprojectnamehere-staging.institution.edu) using a tool like https://www.whatsmydns.net/
 
@@ -74,36 +73,36 @@ This process will differ slightly from previous builds in that there is work to 
 
 The instructions that follow below will have either a `On Local` or a `On Remote Staging` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Staging` and for future ISLE updates and upgrades.
 
-**Steps 1 - 6** - `On Local - Configure the ISLE Staging environment profile for deploy to Remote`
+**Steps 1-6: On Local - Configure the ISLE Staging Environment Profile for Deploy to Remote**
 
-  * Step 1: Copy Production data to your local
-  * Step 2: On Local - Shutdown any local containers & review local code
-  * Step 3: On Local - Create new users and passwords by editing `staging.env`
-  * Step 4: On Local - Review and edit docker-compose.staging.yml
-  * Step 4A: On Local - (Optional) changes for  docker-compose.staging.yml
-  * Step 5: On Local Staging - If using Commercial SSLs
-  * Step 6: On Local - Commit ISLE code to git repository
+  * Step 1: Copy Production Data to Your Local
+  * Step 2: On Local - Shutdown Any Local Containers & Review Local Code
+  * Step 3: On Local - Create New Users and Passwords by Editing "staging.env"
+  * Step 4: On Local - Review and Edit "docker-compose.staging.yml"
+  * Step 4A: On Local - (Optional) Changes for "docker-compose.staging.yml"
+  * Step 5: On Local Staging - If Using Commercial SSLs
+  * Step 6: On Local - Commit ISLE Code to Git Repository
 
-**Steps 7 - 18**   - `On Remote Staging - Configure the ISLE Staging environment profile for launch and usage`
+**Steps 7-18: On Remote Staging - Configure the ISLE Staging Environment Profile for Launch and Usage**
 
-  * Step 7: On Remote Staging - Git clone the ISLE repository to the remote Staging ISLE host server
-  * Step 8: On Remote Staging - Create the appropriate local data paths for Apache, Fedora and log data
-  * Step 9: On Remote Staging - Clone your Production Islandora code
-  * Step 10: On Remote Staging - Copy over the Production Data directories
-  * Step 11: On Remote Staging - If using Let's Encrypt
-  * Step 12: On Remote Staging - Edit the .env file to change to the Staging environment
-  * Step 13: On Remote Staging - Download the ISLE images
+  * Step 7: On Remote Staging - Git Clone the ISLE Repository to the Remote Staging ISLE Host Server
+  * Step 8: On Remote Staging - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
+  * Step 9: On Remote Staging - Clone Your Production Islandora Code
+  * Step 10: On Remote Staging - Copy Over the Production Data Directories
+  * Step 11: On Remote Staging - If Using Let's Encrypt
+  * Step 12: On Remote Staging - Edit the ".env" File to Change to the Staging Environment
+  * Step 13: On Remote Staging - Download the ISLE Images
   * Step 14: On Remote Staging - Start Containers
-  * Step 15: On Remote Staging - Import the Production MySQL Drupal database
-  * Step 16: On Remote Staging - Run ISLE scripts
-  * Step 17: On Remote Staging - Re-index Fedora & Solr
-  * Step 18: On Remote Staging - Review and test the Drupal Staging site
+  * Step 15: On Remote Staging - Import the Production MySQL Drupal Database
+  * Step 16: On Remote Staging - Run ISLE Scripts
+  * Step 17: On Remote Staging - Re-Index Fedora & Solr
+  * Step 18: On Remote Staging - Review and Test the Drupal Staging Site
 
 ---
 
-## Step 1: Copy Production data to your local
+## Step 1: Copy Production Data to Your Local
 
-### Drupal site database
+### Drupal Site Database
 
 You are repeating this step given that data may have changed on the Production site since creating your local. It is critical that Staging be a mirror or close to exact copy of Production.
 
@@ -119,7 +118,7 @@ You are repeating this step given that data may have changed on the Production s
 
 * If possible, on the production Apache webserver, run `drush cc all` from the command line on the production server in the `/var/www/html` directory PRIOR to any db export(s). Otherwise issues can occur on import due to all cache tables being larger than `innodb_log_file_size` allows
 
-#### Production Islandora Drupal site database export process
+#### Export the Production MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current Production Islandora Drupal site in use and copy it to your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your Production site. If you are not comfortable or familiar with performing these actions, we recommend that you instead work with your available IT resources to do so.
     * You can use a MySQL GUI client for this process or if you have command line access to the MySQL database server
@@ -128,33 +127,33 @@ You are repeating this step given that data may have changed on the Production s
 
 ---
 
-## Step 2: On Local - Shutdown any local containers & review local code
+## Step 2: On Local - Shutdown Any Local Containers & Review Local Code
 
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
-* Once finished, open a `terminal` (Windows: open `PowerShell`)
+* Once finished, open a `terminal` (Windows: open `Git Bash`)
     * Navigate to your local ISLE directory
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
 
-## Step 3: On Local - Create new users and passwords by editing `staging.env`
+## Step 3: On Local - Create New Users and Passwords by Editing "staging.env"
 
-* Open up the `staging.env` file in a text editor.
+* Open the "staging.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
         * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Staging` environment but we strongly recommend not reusing all passwords for environments e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment.
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open up the `config/apache/settings_php/settings.staging.php` file.
+* Open the `config/apache/settings_php/settings.staging.php` file.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
 
 ---
 
-## Step 4: On Local - Review and edit docker-compose.staging.yml
+## Step 4: On Local - Review and Edit "docker-compose.staging.yml"
 
 * Review the disks and volumes on your remote `Staging` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.staging.yml` file.
 
@@ -167,7 +166,7 @@ You are repeating this step given that data may have changed on the Production s
 
 * Review the your `docker-compose.local.yml` file for custom edits made and copy them to the `docker-compose.staging.yml` file as needed, this can include changes to Fedora Gsearch Transforms, Fedora hash size and more.
 
-### SSL certificates
+### SSL Certificates
 
 * Depending on your choice of SSL type (Commercial SSL files or the Let's Encrypt service), you'll need to uncomment only one line of the `traefik` services section. There are also inline instructions to this effect in the `docker-compose.staging.yml` file.
     * To use `Let's Encrypt for SSL`, uncomment:
@@ -181,7 +180,7 @@ You are repeating this step given that data may have changed on the Production s
 
 ---
 
-## Step 4A: On Local - (Optional) changes for  docker-compose.staging.yml
+## Step 4A: On Local - (Optional) Changes for "docker-compose.staging.yml"
 
 This section is for optional changes for the `docker-compose.staging.yml`, end-users do not have feel like they have to make any choices here and can continue to **Step 4** as needed.
 
@@ -213,7 +212,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 ---
 
-## Step 5: On Local Staging - If using Commercial SSLs
+## Step 5: On Local Staging - If Using Commercial SSLs
 
 If you are going to use Let's Encrypt instead, you can skip this step and move onto the next one. There will be additional steps further in this document, to help you configure it.
 
@@ -246,7 +245,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## Step 6: On Local - Commit ISLE code to git repository
+## Step 6: On Local - Commit ISLE Code to Git Repository
 
 * Once you have made all of the appropriate changes to your `Staging` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
@@ -255,9 +254,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## On Remote Staging - Configure the ISLE Staging environment profile for launch and usage
+## On Remote Staging - Configure the ISLE Staging Environment Profile for Launch and Usage
 
-## Step 7: On Remote Staging - Git clone the ISLE repository to the remote Staging ISLE host server
+## Step 7: On Remote Staging - Git Clone the ISLE Repository to the Remote Staging ISLE Host Server
 
 * This assumes you have setup an `Islandora` deploy user. If not use a different non-root user for this purpose.
 
@@ -269,7 +268,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 * Clone your ISLE project repository with the newly committed changes for `Staging` to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
-    * This may take a few minutes (2 - 4) depending on your server's Internet connection.
+    * This may take a few minutes (2-4) depending on your server's Internet connection.
 
 * Move the newly cloned directory to the `/opt` directory as the root user
     * `sudo mv /home/islandora/yourprojectnamehere-isle /opt/yourprojectnamehere-isle`
@@ -279,7 +278,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 8: On Remote Staging - Create the appropriate local data paths for Apache, Fedora and log data
+## Step 8: On Remote Staging - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
 
 * Create the `/opt/data` directory
     * `sudo mkdir -p /opt/data`
@@ -288,7 +287,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 9: On Remote Staging - Clone your Production Islandora code
+## Step 9: On Remote Staging - Clone Your Production Islandora Code
 
 Please clone from your existing Production Islandora git repository.
 
@@ -299,11 +298,11 @@ Please clone from your existing Production Islandora git repository.
 
 ---
 
-## Step 10: On Remote Staging - Copy over the Production Data directories
+## Step 10: On Remote Staging - Copy Over the Production Data Directories
 
 * It is recommended that you schedule a content freeze for all Production Fedora ingests and additions to your Production website. This will allow you to get up to date data from Production to Staging.
 
-* As you may have made some critical decisions potentially from `Step 0: Copy Production data to your local` of the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions, you need to re-follow the steps to get your:
+* As you may have made some critical decisions potentially from "Step 0: Copy Production Data to Your Local" of the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions, you need to re-follow the steps to get your:
     * `Production` Drupal site `files` directory
     * `Solr schema & Islandora transforms`
         * If you picked **Easy** option:
@@ -320,7 +319,7 @@ Please clone from your existing Production Islandora git repository.
 
 ---
 
-## Step 11: On Remote Staging - If using Let's Encrypt
+## Step 11: On Remote Staging - If Using Let's Encrypt
 
 If you are using Commercial SSLs, then please stop and move onto the next step.
 
@@ -335,7 +334,7 @@ If using Let's Encrypt, please continue to follow this step.
 
 ---
 
-## Step 12: On Remote Staging - Edit the .env file to change to the Staging environment
+## Step 12: On Remote Staging - Edit the ".env" File to Change to the Staging Environment
 
 This step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit that never gets pushed back to the git repository is critical to allow future ISLE updates or config changes.
 
@@ -401,10 +400,10 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 ---
 
-## Step 13: On Remote Staging - Download the ISLE images
+## Step 13: On Remote Staging - Download the ISLE Images
 
 * Download all of the latest ISLE Docker images (_~6 GB of data may take 5-10 minutes_).
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * Navigate to the root of your ISLE project
     * `cd ~/opt/yourprojectnamehere`
     * `docker-compose pull`
@@ -415,12 +414,12 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 **Please note:** Prior to starting the launch process, it is recommended that you briefly open your firewall to allow ports 80 and 443 access to the world. You'll only need to keep this open for 3 -5 minutes and then promptly close access once the Let's Encrypt SSL certificates have been generated.
 
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * `docker-compose up -d`
 
 * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
 
-* After the above process is completed using the already open terminal or Powershell again.
+* _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
     * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
@@ -432,7 +431,7 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 ---
 
-## Step 15: On Remote Staging - Import the Local MySQL Drupal database
+## Step 15: On Remote Staging - Import the Local MySQL Drupal Database
 
 **Prior to attempting this step, please consider the following:**
 
@@ -442,48 +441,48 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 ---
 
-### Local Islandora Drupal site database import process
+### Import the Local MySQL Islandora Drupal Database
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Staging server.
 
 * Import the exported `Local` MySQL database for use in the current `Staging` Drupal site. Refer to your `staging.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
-    * _Using the same open terminal / Powershell_  
-    * Shell into your currently running `Staging` MySQL container
-        * `docker exec -it yourmysql-container-name bash`
-    * Import the Local Islandora Drupal database. Replace the `DRUPAL_DB` & `DRUPAL_DB_USER` below in the command with the values found in your `staging.env`.
+    * _Using the same open terminal:_  
+    * Shell into your currently running "Staging" MySQL container
+        * `docker exec -it your-mysql-containername bash`
+    * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "staging.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
-        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the `staging.env`)
+        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the "staging.env")
         * This might take a few minutes depending on the size of the file.
-        * Exit out of the container when finished.
+        * Type `exit` to exit the container
 
 ---
 
-## Step 16: On Remote Staging - Run ISLE scripts
+## Step 16: On Remote Staging - Run ISLE Scripts
 
-You can determine the name of the Apache container by running `docker ps`. make note of the Apache container name, you'll need to use it for the commands below.
+This step will show you how to run the "migration_site_vsets.sh" script on the Apache container to change Drupal database site settings for ISLE connectivity.
 
-### Run migration_site_vsets.sh script on the Apache container
+ _Using the same open terminal:_
+ 
+* Run `docker ps` to determine the apache container name
+* Copy the "migration_site_vsets.sh" to the root of the Drupal directory on your Apache container
+    * `docker cp ./scripts/apache/migration_site_vsets.sh your-apache-containername:/var/www/html/migration_site_vsets.sh`
+* Change the permissions on the script to make it executable
+    * `docker exec -it your-apache-containername bash -c "chmod +x /var/www/html/migration_site_vsets.sh"`
+* Run the script
+    * `docker exec -it your-apache-containername bash -c "cd /var/www/html && ./migration_site_vsets.sh"`
 
-* _Using the same open terminal / Powershell_
-    * Run the `migration_site_vsets.sh` script on the Apache container. This will change Drupal database site settings only for ISLE connectivity.
-    * Copy the `./scripts/apache/migration_site_vsets.sh` to the root of the Drupal directory on your Apache container
-        * `docker cp ./scripts/apache/migration_site_vsets.sh yourapache-container-name:/var/www/html/migration_site_vsets.sh`
-    * Change the permissions on the script to make it executable
-        * `docker exec -it your-apache-containername chmod +x /var/www/html/migration_site_vsets.sh`
-    * Run the script
-        * `docker exec -it your-apache-containername bash /var/www/html/migration_site_vsets.sh`
+This step will show you how to shell into your currently running "Staging" Apache container, and run the "fix-permissions.sh" script to fix the Drupal site permissions.
 
-### Run fix-permissions.sh script on the Apache container
-* You'll need to fix the Drupal site permissions by running the `/fix-permissions.sh` script from the Apache container
-  * Shell into your currently running `Staging` Apache container
-    * `docker exec -it yourapache-container-name bash`
-    * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
-    * This process will take 2 - 5 mins depending
-    * Type `exit` to exit the container
+* `docker exec -it your-apache-containername bash`
+* `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
+* This process will take 2-5 minutes
+* You should see a lot of green [ok] messages.
+* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
+* Type `exit` to exit the container
 
-| For Windows Users only |
+| Microsoft Windows |
 | :-------------      |
 | You may be prompted by Windows to: |
 | - Share the C drive with Docker.  Click Okay or Allow.|
@@ -491,11 +490,9 @@ You can determine the name of the Apache container by running `docker ps`. make 
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-
 ---
 
-## Step 17: On Remote Staging - Re-index Fedora & Solr
+## Step 17: On Remote Staging - Re-Index Fedora & Solr
 
 When migrating any non-ISLE Islandora site, it is crucial to rebuild (reindex) the following three indices from the FOXML and datastream files on disk.
 
@@ -515,9 +512,9 @@ Since this command can take minutes or hours depending on the size of your repos
 
 **Please note:** The method described below is a longer way of doing this process to onboard users.
 
-* Shell into your currently running `Staging` Fedora container
+* Shell into your currently running "Staging" Fedora container
     * Run `docker ps` to determine the Fedora container name
-    * `docker exec -it yourfedora-container-name bash`
+    * `docker exec -it your-fedora-containername bash`
 
 * Navigate to the `utility_scripts` directory
     * `cd utility_scripts`
@@ -552,7 +549,7 @@ OK - Started application at context path [/fedora]
 
 ### Reindex Solr (3/3)
 
-**WARNING** - This reindex process takes the longest of all three, with up to **1 - 30 or more hours** to complete depending on the size of your Fedora collection. As such, it is recommended starting a screen session prior to running the following command. Learn more about [screen here](https://www.tecmint.com/screen-command-examples-to-manage-linux-terminals/)
+**WARNING** - This reindex process takes the longest of all three, with up to **1-30 or more hours** to complete depending on the size of your Fedora collection. As such, it is recommended starting a screen session prior to running the following command. Learn more about [screen here](https://www.tecmint.com/screen-command-examples-to-manage-linux-terminals/)
 
 * Still staying within the `utility_scripts` directory on the Fedora container or reenter the Fedora container having started a new screen session, now run the `updateSolrIndex.sh` script. This script will give you output like the example below.
     * `./updateSolrIndex.sh`
@@ -585,12 +582,12 @@ Args
 
 ---
 
-## Step 18: On Remote Staging - Review and test the Drupal Staging site
+## Step 18: On Remote Staging - Review and Test the Drupal Staging Site
 
 * In your web browser, enter this URL: `https://yourprojectnamehere.institution.edu`
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
-* Log in to the local Islandora site with the credentials you created in `staging.env` (`DRUPAL_ADMIN_USER` and `DRUPAL_ADMIN_PASS`)
+* Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "staging.env".
     * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.

--- a/docs/install/install-staging-new.md
+++ b/docs/install/install-staging-new.md
@@ -1,6 +1,6 @@
 # Staging ISLE Installation: New Site
 
-_Expectations:  It takes an average of **2 - 4+ hours** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
 This `Staging` ISLE Installation will use the themed Drupal website created during the [Local ISLE Installation: New Site](../install/install-local-new.md) process and will create an empty Fedora repository for remote (non-local / cloud) hosting of a `Staging` site. Islandora Drupal site code here should be considered almost finished but hosted here for last touches and team review privately prior to pushing to public `Production`. Fedora data might have tests collections or collections that should then be synced to the `Production` site. It is recommended that this remote site not be publicly accessible.
 
@@ -35,7 +35,7 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
         * [Hardware Requirements](host-hardware-requirements.md)
         * [Software Dependencies](host-software-dependencies.md)
     * This server should be running at the time of deploy.
-    * This server has enough disk space to store a large Fedora repository e.g. 1 - 5 TB or larger depending on how many objects you plan on ingesting.  
+    * This server has enough disk space to store a large Fedora repository e.g. 1-5 TB or larger depending on how many objects you plan on ingesting.  
 
 * You have already created the two private git repositories for your projects ISLE and Islandora code in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc. having followed Step 2 from the [Local ISLE Installation: New Site](../install/install-local-new.md) instructions. You will continue to use these two git repositories for all environments.
     1. ISLE project config - e.g. `yourprojectnamehere-isle`
@@ -55,36 +55,36 @@ This process will differ slightly from previous builds in that there is work to 
 
 The instructions that follow below will have either a `On Local` or a `On Remote Staging` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Staging` and for future ISLE updates and upgrades.
 
-**Steps 1 - 6** - `On Local - Configure the ISLE Staging environment profile for deploy to Remote`
+**Steps 1-6: On Local - Configure the ISLE Staging Environment Profile for Deploy to Remote**
 
-  * Step 1: On Local - Export the Local MySQL database
-    * Local Islandora Drupal site database export process
-  * Step 2: On Local - Shutdown any local containers & review local code
-  * Step 3: On Local - Create new users and passwords by editing `staging.env`
-  * Step 4: On Local - Review and edit docker-compose.staging.yml
-  * Step 4A: On Local - (Optional) changes for  docker-compose.staging.yml
-  * Step 5: On Local Staging - If using Commercial SSLs
-  * Step 6: On Local - Commit ISLE code to git repository
+  * Step 1: On Local - Export the Local MySQL Database
+      * Export the Local MySQL Islandora Drupal Database
+  * Step 2: On Local - Shutdown Any Local Containers & Review Local Code
+  * Step 3: On Local - Create New Users and Passwords by Editing "staging.env"
+  * Step 4: On Local - Review and Edit "docker-compose.staging.yml"
+  * Step 4A: On Local - (Optional) Changes for "docker-compose.staging.yml"
+  * Step 5: On Local Staging - If Using Commercial SSLs
+  * Step 6: On Local - Commit ISLE Code to Git Repository
 
-**Steps 7 - 17**   - `On Remote Staging - Configure the ISLE Staging environment profile for launch and usage`
+**Steps 7-17: On Remote Staging - Configure the ISLE Staging Environment Profile for Launch and Usage**
 
-  * Step 7: On Remote Staging - Git clone the ISLE repository to the remote Staging ISLE host server
-  * Step 8: On Remote Staging - Create the appropriate local data paths for Apache, Fedora and log data
-  * Step 9: On Remote Staging - Clone your Islandora code
-  * Step 10: On Remote Staging - Copy over the Local Islandora Drupal files directory
-  * Step 11: On Remote Staging - If using Let's Encrypt
-  * Step 12: On Remote Staging - Edit the .env file to change to the Staging environment
-  * Step 13: On Remote Staging - Download the ISLE images
+  * Step 7: On Remote Staging - Git Clone the ISLE Repository to the Remote Staging ISLE Host Server
+  * Step 8: On Remote Staging - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
+  * Step 9: On Remote Staging - Clone Your Islandora Code
+  * Step 10: On Remote Staging - Copy Over the Local Islandora Drupal Files Directory
+  * Step 11: On Remote Staging - If Using Let's Encrypt
+  * Step 12: On Remote Staging - Edit the ".env" File to Change to the Staging Environment
+  * Step 13: On Remote Staging - Download the ISLE Images
   * Step 14: On Remote Staging - Start Containers
-  * Step 15: On Remote Staging - Import the Local MySQL Drupal database
-  * Step 16: On Remote Staging - Run the fix-permissions.sh script
-  * Step 17: On Remote Staging - Review and test the Drupal Staging site
+  * Step 15: On Remote Staging - Import the Local MySQL Drupal Database
+  * Step 16: On Remote Staging - Run the "fix-permissions.sh" Script
+  * Step 17: On Remote Staging - Review and Test the Drupal Staging Site
 
 ---
 
-## On Local - Configure the ISLE Staging environment profile for deploy to Remote
+## On Local - Configure the ISLE Staging Environment Profile for Deploy to Remote
 
-## Step 1: On Local - Export the Local MySQL database
+## Step 1: On Local - Export the Local MySQL Database
 
 **Prior to attempting this step, please consider the following:**
 
@@ -94,48 +94,48 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 * If possible, on the production Apache webserver, run `drush cc all` from the command line on the local Apache container in the `/var/www/html` directory PRIOR to any db export(s). Otherwise issues can occur on import due to all cache tables being larger than `innodb_log_file_size` allows
 
-### Local Islandora Drupal site database export process
+### Export the Local MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current `Local` Drupal site in use and copy it on your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your newly created and themed new Islandora site. Refer to your `local.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Shell into your currently running Local MySQL container
-        * `docker exec -it yourmysql-container-name bash`
-    * Export the Local Islandora Drupal database. Replace the `DRUPAL_DB` & `DRUPAL_DB_USER` below in the command with the values found in your `local.env`.
+        * `docker exec -it your-mysql-containername bash`
+    * Export the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "local.env" file.
         * `mysqldump -u DRUPAL_DB_USER -p DRUPAL_DB > local_drupal_site_082019.sql`
-        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the `local.env`)
+        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the "local.env")
         * Upon completion, exit the MySQL container  
     * Copy this file from the MySQL container to a location on your personal computer.
-        * `docker cp yourmysql-container-name:/local_drupal_site_082019.sql /path/to/location`
+        * `docker cp your-mysql-containername:/local_drupal_site_082019.sql /path/to/location`
 
 ---
 
-## Step 2: On Local - Shutdown any local containers & review local code
+## Step 2: On Local - Shutdown Any Local Containers & Review Local Code
 
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
-* Once finished, open a `terminal` (Windows: open `PowerShell`)
+* Once finished, open a `terminal` (Windows: open `Git Bash`)
     * Navigate to your local ISLE directory
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
 
-## Step 3: On Local - Create new users and passwords by editing staging.env
+## Step 3: On Local - Create New Users and Passwords by Editing "staging.env"
 
-* Open up the `staging.env` file in a text editor.
+* Open the "staging.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
         * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Staging` environment but we strongly recommend not reusing all passwords for environments e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment.
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open up the `config/apache/settings_php/settings.staging.php` file.
+* Open the `config/apache/settings_php/settings.staging.php` file.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
 
 ---
 
-## Step 4: On Local - Review and edit docker-compose.staging.yml
+## Step 4: On Local - Review and Edit "docker-compose.staging.yml"
 
 * Review the disks and volumes on your remote `Staging` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.staging.yml` file.
 
@@ -156,7 +156,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 * Based on the choice of SSL type made above, you'll need to refer to to the `./config/proxy/traefik.staging.toml` file for further configuration instructions.
 
-## Step 4A: On Local - (Optional) changes for docker-compose.staging.yml
+## Step 4A: On Local - (Optional) Changes for "docker-compose.staging.yml"
 
 This section is for optional changes for the `docker-compose.staging.yml`, end-users do not have feel like they have to make any choices here and can continue to **Step 4** as needed.
 
@@ -188,7 +188,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 ---
 
-## Step 5: On Local Staging - If using Commercial SSLs
+## Step 5: On Local Staging - If Using Commercial SSLs
 
 If you are going to use Let's Encrypt instead, you can skip this step and move onto the next one. There will be additional steps further in this document, to help you configure it.
 
@@ -221,7 +221,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## Step 6: On Local - Commit ISLE code to git repository
+## Step 6: On Local - Commit ISLE Code to Git Repository
 
 * Once you have made all of the appropriate changes to your `Staging` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
@@ -230,9 +230,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ---
 
-## On Remote Staging - Configure the ISLE Staging environment profile for launch and usage
+## On Remote Staging - Configure the ISLE Staging Environment Profile for Launch and Usage
 
-## Step 7: On Remote Staging - Git clone the ISLE repository to the remote Staging ISLE host server
+## Step 7: On Remote Staging - Git Clone the ISLE Repository to the Remote Staging ISLE Host Server
 
 * This assumes you have setup an `Islandora` deploy user. If not use a different non-root user for this purpose.
 
@@ -244,7 +244,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 * Clone your ISLE project repository with the newly committed changes for `Staging` to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
-    * This may take a few minutes (2 - 4) depending on your server's Internet connection.
+    * This may take a few minutes (2-4) depending on your server's Internet connection.
 
 * Move the newly cloned directory to the `/opt` directory as the root user
     * `sudo mv /home/islandora/yourprojectnamehere-isle /opt/yourprojectnamehere-isle`
@@ -254,7 +254,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 8: On Remote Staging - Create the appropriate local data paths for Apache, Fedora and log data
+## Step 8: On Remote Staging - Create the Appropriate Local Data Paths for Apache, Fedora and Log Data
 
 * Create the `/opt/data` directory
     * `sudo mkdir -p /opt/data`
@@ -263,7 +263,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 9: On Remote Staging - Clone your Islandora code
+## Step 9: On Remote Staging - Clone Your Islandora Code
 
 * `git clone git@yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git /opt/data/apache/html`
 
@@ -272,7 +272,7 @@ Since the `/opt` directory might not let you do this at first, we suggest the fo
 
 ---
 
-## Step 10: On Remote Staging - Copy over the Local Islandora Drupal files directory
+## Step 10: On Remote Staging - Copy Over the Local Islandora Drupal Files Directory
 
 This `files` directory should be on your personal computer and should be copied to the remote Staging server.
 
@@ -283,7 +283,7 @@ This `files` directory should be on your personal computer and should be copied 
 
 ---
 
-## Step 11: On Remote Staging - If using Let's Encrypt
+## Step 11: On Remote Staging - If Using Let's Encrypt
 
 If you are using Commercial SSLs, then please stop and move onto the next step.
 
@@ -298,7 +298,7 @@ If using Let's Encrypt, please continue to follow this step.
 
 ---
 
-## Step 12: On Remote Staging - Edit the .env file to change to the Staging environment
+## Step 12: On Remote Staging - Edit the ".env" File to Change to the Staging Environment
 
 This step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit that never gets pushed back to the git repository is critical to allow future ISLE updates or config changes.
 
@@ -364,10 +364,10 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 ---
 
-## Step 13: On Remote Staging - Download the ISLE images
+## Step 13: On Remote Staging - Download the ISLE Images
 
 * Download all of the latest ISLE Docker images (_~6 GB of data may take 5-10 minutes_):
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * Navigate to the root of your ISLE project
     * `cd ~/opt/yourprojectnamehere`
     * `docker-compose pull`
@@ -378,12 +378,12 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 **Please note:** Prior to starting the launch process, it is recommended that you briefly open your firewall to allow ports 80 and 443 access to the world. You'll only need to keep this open for 3 -5 minutes and then promptly close access once the Let's Encrypt SSL certificates have been generated.
 
-* _Using the same open terminal / Powershell_
+* _Using the same open terminal:_
     * `docker-compose up -d`
 
 * Please wait a few moments for the stack to fully come up. Approximately 3-5 minutes.
 
-* After the above process is completed using the already open terminal or Powershell again.
+* _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
     * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
@@ -395,7 +395,7 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 ---
 
-## Step 15: On Remote Staging - Import the Local MySQL Drupal database
+## Step 15: On Remote Staging - Import the Local MySQL Drupal Database
 
 **Prior to attempting this step, please consider the following:**
 
@@ -405,33 +405,35 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 ---
 
-### Local Islandora Drupal site database import process
+### Import the Local MySQL Islandora Drupal Database
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Staging server.
 
 * Import the exported `Local` MySQL database for use in the current `Staging` Drupal site. Refer to your `staging.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
-    * Shell into your currently running `Staging` MySQL container
-        * `docker exec -it yourmysql-container-name bash`
-    * Import the Local Islandora Drupal database. Replace the `DRUPAL_DB` & `DRUPAL_DB_USER` below in the command with the values found in your `staging.env`.
+    * Shell into your currently running "Staging" MySQL container
+        * `docker exec -it your-mysql-containername bash`
+    * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "staging.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
-        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the `staging.env`)
+        * Enter the appropriate password: value of `DRUPAL_DB_PASS` in the "staging.env")
         * This might take a few minutes depending on the size of the file.
-        * Exit out of the container when finished.
+        * Type `exit` to exit the container
 
 ---
 
-## Step 16: On Remote Staging - Run the fix-permissions.sh script
+## Step 16: On Remote Staging - Run the "fix-permissions.sh" Script
 
 * You'll need to fix the Drupal site permissions by running the `/fix-permissions.sh` script from the Apache container
     * Run `docker ps` to determine the Apache container name
-    * Shell into your currently running `Staging` Apache container
-        * `docker exec -it yourapache-container-name bash`
+    * Shell into your currently running "Staging" Apache container
+        * `docker exec -it your-apache-containername bash`
         * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
-        * This process will take 2 - 5 mins depending
+        * This process will take 2-5 minutes
+        * You should see a lot of green [ok] messages.
+        * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
 
-| For Windows Users only |
+| Microsoft Windows |
 | :-------------      |
 | You may be prompted by Windows to: |
 | - Share the C drive with Docker.  Click Okay or Allow.|
@@ -439,18 +441,16 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* You should see a lot of green [ok] messages.
-* If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-* **Proceed only after this message appears:** `Clearing Drupal Caches. 'all' cache was cleared.`
+* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
 
 ---
 
-## Step 17: On Remote Staging - Review and test the Drupal Staging site
+## Step 17: On Remote Staging - Review and Test the Drupal Staging Site
 
 * In your web browser, enter this URL: `https://yourprojectnamehere-staging.institution.edu`
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
-* Log in to the local Islandora site with the credentials you created in `staging.env` (`DRUPAL_ADMIN_USER` and `DRUPAL_ADMIN_PASS`)
+* Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "staging.env".
     * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.

--- a/docs/install/install-troubleshooting.md
+++ b/docs/install/install-troubleshooting.md
@@ -106,11 +106,11 @@ Once your web server(s) have been disabled, resume the ISLE install process by r
 As of ISLE release logging to physical file has been turned off, stdout & stderr are to console only no more physical files. This means if you need to view logs for debugging, here are some methods:
 
 * [Docker method:](https://docs.docker.com/engine/reference/commandline/logs/) (_when using the Docker json driver and TICK is not on_)
-  * Single container: `docker logs -f <container-name>`
+  * Single container: `docker logs -f <containername>`
   * All containers: `docker logs --tail=0 --follow`
 
 * [Docker-compose method:(https://docs.docker.com/compose/reference/logs/)] (when using the Docker json driver and TICK is not on)
-Single container: docker-compose logs -f  <container-name>
+Single container: docker-compose logs -f  <containername>
 All containers: docker-compose logs --tail=0 --follow
 
 * Use the [TICK Log viewer](../optional-components/tickstack.md) if TICK is setup and using the Docker syslog driver (Production / Staging only) 

--- a/docs/optional-components/blazegraph.md
+++ b/docs/optional-components/blazegraph.md
@@ -57,13 +57,13 @@
   
   * Add an additional 2 GB RAM in total ISLE Host memory for Blazegraph to run
   
-  * Plan on an additional 25 - 100+ GB disk space for “big_data” resource index persistence.
+  * Plan on an additional 25-100+ GB disk space for “big_data” resource index persistence.
     * This index (`/var/bigdata/bigdata.jnl`) will grow quickly overtime and file sizes of over 25GB or more are possible with Fedora repositories that have over 1 million objects.
 
   * To persist this file and directory in a bind-mount instead of a Docker volume, an edit will need to be made to the `docker-compose.yml` file in the `blazegraph` service, `volume` section.
-    * Change `isle-blazegraph-data` to your ISLE Host system specific bind-mount path. For example: 
+    * Change `isle-blazegraph-data` to your ISLE Host system specific bind-mount path. **Example:** 
       * `- /mnt/isle-blazegraph-data:/var/bigdata`
-  * This disk should be a separate data disk that should be 25 - 100+ GB in capacity. Plan on resizing this disk when using Blazegraph with large Fedora repositories of over 600K+ of objects.
+  * This disk should be a separate data disk that should be 25-100+ GB in capacity. Plan on resizing this disk when using Blazegraph with large Fedora repositories of over 600K+ of objects.
 
 ---
 
@@ -358,7 +358,7 @@ FEDORA_WEBAPP_HOME=/usr/local/tomcat/webapps/fedora
 * Spin up new containers
   * `docker-compose up -d`
 
-* Wait a few minutes (_3 - 8 depending on the size of your site_) for the site and services to come up.
+* Wait a few minutes (_3-8 depending on the size of your site_) for the site and services to come up.
 
 #### Check Fedora
 
@@ -440,7 +440,7 @@ SELECT (COUNT(*) AS ?triples) WHERE {?s ?p ?o}
         tag: "{{.Name}}"
 ```
 
-**For example:**
+****Example:****
 
 ```bash
 
@@ -468,7 +468,7 @@ SELECT (COUNT(*) AS ?triples) WHERE {?s ?p ?o}
 
 * Additionally you'll need to remove or comment out every line or reference to logs from the `volumes` section of each service.
 
-**For example:**
+****Example:****
 
 ```bash
     volumes:

--- a/docs/optional-components/tickstack.md
+++ b/docs/optional-components/tickstack.md
@@ -69,8 +69,8 @@ The use and setup of TICK within the ISLE platform is as an optional [sidecar](h
 * Additional systems overhead, including:
 
 * For any system that is running the full TICK stack as a side car
-    * Recommend an additional 2 - 3 GB of RAM
-    * Recommend an additional 5 - 10 GB of storage disk space
+    * Recommend an additional 2-3 GB of RAM
+    * Recommend an additional 5-10 GB of storage disk space
 
 * For any system that is running the Telegraf agent only
     * Recommend an additional 512MB to 1 GB of RAM

--- a/docs/optional-components/varnish.md
+++ b/docs/optional-components/varnish.md
@@ -59,7 +59,7 @@
 
 * Additional systems overhead, including:
 
-  * Add an additional 1 - 2 GB RAM in total ISLE Host memory for Varnish to keep the cache in memory.
+  * Add an additional 1-2 GB RAM in total ISLE Host memory for Varnish to keep the cache in memory.
     * You can adjust the amount that Varnish puts into memory in the supplied `.env` file
       * On the line: `VARNISH_MALLOC=256m` you can change the amount of memory to a higher value other than the default `256` Megabytes. We recommend that you do not attempt to exceed 1 GB for now.
 
@@ -349,7 +349,7 @@ VARNISH_VARNISH_PORT=6081
         tag: "{{.Name}}"
 ```
 
-**For example:**
+****Example:****
 
 ```bash
 varnish:
@@ -380,7 +380,7 @@ varnish:
 
 * Additionally you'll need to remove or comment out every line or reference to logs from the `volumes` section of each service. Varnish by default doesn't log unless directed to manually.
 
-**For example:**
+****Example:****
 
 ```bash
     volumes:

--- a/docs/release-notes/release-1-2-0.md
+++ b/docs/release-notes/release-1-2-0.md
@@ -32,11 +32,11 @@
 * Logging to physical files is turned off in each Docker container.  To view the logs now, you can use
   one of these methods:
   * Docker method: (when using the Docker json driver and TICK is not on)
-    * Single container: docker logs -f <container-name>
+    * Single container: docker logs -f <containername>
     * All containers: docker logs --tail=0 --follow
     * To learn more: https://docs.docker.com/engine/reference/commandline/logs/
   * Docker-compose method: (when using the Docker json driver and TICK is not on)
-    * Single container: docker-compose logs -f  <container-name>
+    * Single container: docker-compose logs -f  <containername>
     * All containers: docker-compose logs --tail=0 --follow
     * To learn more: https://docs.docker.com/compose/reference/logs/
   * Use the TICK Log viewer if TICK is setup and using the Docker syslog driver. Please read the 

--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -14,7 +14,7 @@ We strongly recommend that you start the update process on your `Local` environm
 
 On your Local version of ISLE:
 
-* In the command line, navigate to the ISLE directory, which should contain the `docker-compose.local.yml` file.
+* In the command line (Windows: open Git Bash), navigate to the ISLE directory, which should contain the `docker-compose.local.yml` file.
 
 * Stop and remove your existing ISLE containers
     * `docker-compose down`
@@ -47,7 +47,7 @@ On your Local version of ISLE:
 
 * You can choose to push this new branch to your remote git or keep it on your local. Ultimately after testing on your local, you'll merge to `master` and then deploy the new code to your `Staging` and `Production` environments.
 
-* On your local, using the still open terminal / Powershell, pull down the new containers. Be sure to be in the root of your ISLE project directory. Download the new ISLE images.
+* On your local (personal computer), using the same open terminal, pull down the new containers. Be sure to be in the root of your ISLE project directory. Download the new ISLE images.
     * `cd ~/yourprojecthere/`
     * `docker-compose pull`
 
@@ -66,7 +66,7 @@ On your Local version of ISLE:
 
 * Push this code to your online git provider ISLE
     * `git push -u origin master`
-    * This will take 2 - 5 mins depending on your internet speed.
+    * This will take 2-5 mins depending on your internet speed.
 
 * Now you have the current ISLE project code checked into git as foundation to make changes on your `Staging` and `Production` servers.
 
@@ -82,7 +82,7 @@ On your Local version of ISLE:
 * Update the docker files via git
     * `git pull`
 
-* You'll need to fix the `.env` file again as you did in the `On Remote Staging - Edit the .env file to change to the Staging environment` stop of either the [Staging ISLE Installation: New Site](../install/install-staging-new.md) or the [Staging ISLE Installation: Migrate Existing Islandora Site](../install/install-staging-migrate.md) instructions. As described, this step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit that never gets pushed back to the git repository is critical to allow future ISLE updates or config changes. Basically you are just restoring what you had in the `.env` to the `Staging` settings in case they are overwriten.
+* You'll need to fix the `.env` file again as you did in the `On Remote Staging - Edit the ".env" File to Change to the Staging Environment` stop of either the [Staging ISLE Installation: New Site](../install/install-staging-new.md) or the [Staging ISLE Installation: Migrate Existing Islandora Site](../install/install-staging-migrate.md) instructions. As described, this step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit that never gets pushed back to the git repository is critical to allow future ISLE updates or config changes. Basically you are just restoring what you had in the `.env` to the `Staging` settings in case they are overwriten.
 
 * Download the new ISLE docker images on the remote Staging system
     * `docker-compose pull`


### PR DESCRIPTION
# Notes: "Docs: Eliminating Local Window Installation Failure Points"
- Improved docker exec syntax to pass commands as strings; this prevents failures on Windows
	- example: chmod: cannot access 'C:/Program Files/Git/var/www/html/migration_site_vsets.sh': No such file or directory
- **Microsoft Windows:** Instructions for how to preface docker commands with `winpty`
	- to eliminate this Windows error message: `the input device is not a TTY.  If you are using mintty, try prefixing the command with 'winpty'`
- Windows paths for `docker cp` require an extra "forward slash" as an escape to prevent paths from being rendered incorrectly.
    - correct example: `winpty docker cp scripts/apache/migration_site_vsets.sh isle-apache-ld://var/www/html/migration_site_vsets.sh`
- Removed bullets to differentiate between descriptive text explanations and instructions for input to CLi.
- Added instructions for **Microsoft Windows:** Please set your text editor to use UNIX style line endings for files.
- Software Dependencies: Changed Windows command line interface default to be `Git Bash` instead of `Powershell` or `Windows command line`; removed references to Powershell. 