### PR TITLE
Documentation updates for islandoracon and 1.3.0 release

### DIFF
--- a/docs/cookbook-recipes/isle-cheatsheet-docker-commands.md
+++ b/docs/cookbook-recipes/isle-cheatsheet-docker-commands.md
@@ -21,7 +21,7 @@ Docker commands that are useful to installing or updating ISLE.
 ### [Stop Containers](https://docs.docker.com/compose/reference/stop/)
   * `docker-compose stop` # Stops running containers without removing them
   * `docker stop [CONTAINER_NAME(S)]` # Stop one or more named containers
-    * example: `docker stop isle-tomcat isle-solr`
+    * **Example:** `docker stop isle-tomcat isle-solr`
   * `docker stop $(docker ps -a -q)` # **WARNING!** This will stop ALL containers running on the machine.
 
 ### [Stop and Remove Containers](https://docs.docker.com/compose/reference/down/)
@@ -30,24 +30,24 @@ Docker commands that are useful to installing or updating ISLE.
 ### [Pull Containers](https://docs.docker.com/compose/reference/pull/)
   * `docker-compose pull` # Pull down all images from Docker Hub
   * `docker pull [GROUP]/[REPOSITORY]` # Pull one specific image from Docker Hub
-    * example: `docker pull islandoracollabgroup/isle-fedora:latest`
+    * **Example:** `docker pull islandoracollabgroup/isle-fedora:latest`
 
 ### [Up Containers](https://docs.docker.com/compose/reference/up/)
   * `docker-compose up -d` # Launch all containers for this service
 
 ### [Remove Volumes](https://docs.docker.com/engine/reference/commandline/volume_rm/)
   * `docker volume rm [VOLUME_NAME]` # Remove one or more volumes. You cannot remove a volume that is in use by a container.
-    * example: `docker volume rm isle_fed-data`
+    * **Example:** `docker volume rm isle_fed-data`
 
 ### [Remove Containers](https://docs.docker.com/engine/reference/commandline/rm/)
   * `docker rm [CONTAINER_NAME(S)]` # Remove one or more containers
-    * example: `docker rm isle_fed-data`
+    * **Example:** `docker rm isle_fed-data`
 
 ### [Shell Into Docker Container](https://docs.docker.com/v17.12/engine/reference/commandline/exec/)
   * `docker exec -it [CONTAINER_NAME] bash` # Shell Into Docker Container
-    * example: `docker exec -it isle-apache-ld bash`
+    * **Example:** `docker exec -it isle-apache-ld bash`
   * `docker exec -it [CONTAINER_NAME] [FILE_NAME]` # Shell Into Docker Container and Run Script
-    * example: `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
+    * **Example:** `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
 
 ### [Docker Service](https://docs.docker.com/engine/reference/commandline/docker/)
   * `sudo service docker status` # Show Docker Status
@@ -56,11 +56,11 @@ Docker commands that are useful to installing or updating ISLE.
 
 ### [Watching Docker Logs](https://docs.docker.com/engine/reference/commandline/logs/)
   * `docker logs -f --tail 10 [CONTAINER_NAME]` # Show the last 10 lines (`--tail 10`) of a container's logs; `-f` means continuous/live feed
-    * example: `docker logs -f --tail 10 isle-apache-ld`
+    * **Example:** `docker logs -f --tail 10 isle-apache-ld`
 
 ### [Locate Docker Volume](https://docs.docker.com/engine/reference/commandline/volume_inspect/)
   * `docker volume inspect [VOLUME_NAME]` # Locate Docker Volume
-    * example: `docker volume inspect isle_fed-data`
+    * **Example:** `docker volume inspect isle_fed-data`
     * resultant display is a JSON array that contains a location like this:
         * `"Mountpoint": "/var/lib/docker/volumes/isle_fed-data/_data"`
 
@@ -87,21 +87,21 @@ Docker commands that are useful to installing or updating ISLE.
 
 ### Quickly View a File, Using `cat`
   * usage: `cat [FILE_NAME]`
-  * example: `cat /etc/hosts`
+  * **Example:** `cat /etc/hosts`
 
 ### Ping to Test Connectivity
   * usage: `ping [DOMAIN]`
-  * example: `ping www.google.com`
-  * example: `ping isle.localdomain`
+  * **Example:** `ping www.google.com`
+  * **Example:** `ping isle.localdomain`
 
 ### DNS Lookup and Querying Tool
   * usage: `dig [DOMAIN]`
-  * example: `dig www.google.com`
-  * example: `dig isle.localdomain`
+  * **Example:** `dig www.google.com`
+  * **Example:** `dig isle.localdomain`
 
 ### EXTREME CAUTION: Remove Directory: Recursively and with Force
   * usage: `sudo rm -rf [DIRECTORY_NAME]`
-  * example: `sudo rm -rf /var/tmp/scrap/`
+  * **Example:** `sudo rm -rf /var/tmp/scrap/`
 
 
 # *CAREFUL! BELOW THERE BE DRAGONS*

--- a/docs/install/_obsolete_install-server.md
+++ b/docs/install/_obsolete_install-server.md
@@ -164,9 +164,9 @@ A Remote Server ISLE Installation requires that you provision and place a comple
 2. Copy these SSL certificates into the `./ISLE/config/proxy/ssl-certs` directory.
     * You are required to have exactly two files: (names will differ from examples)
         * (1) SSL Certificate Key File (file extension may be: ".key" or ".pem")
-            * Example: `sample-key.key` or `sample-key.pem`
+            * **Example:** `sample-key.key` or `sample-key.pem`
         * (1) SSL Certificate File (file extension may be: ".cer", ".crt" or ".pem")
-            * Example: `sample.cer` or `sample.crt` or `sample.pem`
+            * **Example:** `sample.cer` or `sample.crt` or `sample.pem`
 3. Edit the `./ISLE/config/proxy/traefik.toml` file.
     * Change lines:
       *  `certFile = "/certs/sample.cert"`  ## Change to reflect your ".cer", ".crt" or ".pem"
@@ -209,7 +209,7 @@ This process may take 10-20 minutes (_depending on system and internet speeds_)
 ---
 
 ## Additional Resources
-* TBD: [Demo ISLE Installation: Resources](../install/install-demo-resources.md) contains Docker container passwords and URLs for administrator tools.
+* TBD: [Demo ISLE Installation: Resources](../install/install-demo-resources.md) contains Docker container passwords and URLs for administrator testing.
 * TBD: [Demo ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/host-hardware-requirements.md
+++ b/docs/install/host-hardware-requirements.md
@@ -56,10 +56,9 @@ Below are the recommended minimum specifications for a staging server. The serve
 
 Below are the recommended specifications for a personal computer running a Demo ISLE Installation:
 
-* Your own OS (whatever it is)
+* Your own OS (Mac OSX, Windows 10, Linux, etc.)
 * Minimum of 2 CPU cores
 * 8-16 GB of RAM is recommended
-* 128-500GB for the Desktop OS
 * Sufficient hard drive or attached storage to hold a small test collection (depending on your testing ~5-10GB for objects and their derivatives)
 
 **Please continue by selecting: [Software Dependencies](../install/host-software-dependencies.md).**

--- a/docs/install/host-software-dependencies.md
+++ b/docs/install/host-software-dependencies.md
@@ -19,13 +19,8 @@
     - If you are not already `root`, enter either `sudo -s` or `sudo su` to become root.
 
 - Update and install the following required software:
-```
- apt-get update && upgrade
-```
-
-```
- apt-get install -y openssl git htop ntp wget curl nano apt-transport-https ca-certificates software-properties-common
-```
+    - `apt-get update && upgrade`
+    - `apt-get install -y openssl git htop ntp wget curl nano apt-transport-https ca-certificates software-properties-common`
 
 ### Step 2: Install Docker
 
@@ -38,18 +33,12 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 ```
 - Update package list.
-```
-apt-get update
-```
+    - `apt-get update`
 - Install Docker.
-```
-apt-get install -y docker-ce
-```
+    - `apt-get install -y docker-ce`
 
 - Enable and start Docker.
-```
-systemctl enable docker && systemctl start docker
-```
+    - `systemctl enable docker && systemctl start docker`
 
 ### Step 3: Install Docker-Compose
 
@@ -60,12 +49,9 @@ curl -L https://github.com/docker/compose/releases/download/1.23.1/docker-compos
 ```
 
 - Test the Installation.
-```
-docker-compose --version
-```
+    - `docker-compose --version`
 
-- **Example output:**
-`docker-compose version 1.23.1, build 1110ad01`
+- **Example output:** `docker-compose version 1.23.1, build 1110ad01`
 
 ### Step 4: Add Your User to the `docker` Group
 Allow your user to run Docker commands and to launch the entire ISLE stack.
@@ -73,9 +59,7 @@ Allow your user to run Docker commands and to launch the entire ISLE stack.
 - If you are still `root` (`whoami`), type `exit` to become your normal user.
 
 - Add yourself to the `docker` group.
-```
-sudo usermod -aG docker $USER
-```
+    - `sudo usermod -aG docker $USER`
 
 - Type `exit` and then reconnect (this allows your effective groups to update).
 
@@ -85,16 +69,12 @@ sudo usermod -aG docker $USER
 Please run these steps as your normal user (not `root`):
 
 * Clone the repository:
-```
-git clone https://github.com/Islandora-Collaboration-Group/ISLE.git
-```
+    * `git clone https://github.com/Islandora-Collaboration-Group/ISLE.git`
 
-- Change to the directory containing ISLE.
-```
-cd ISLE
-```
+* Change to the directory containing ISLE:
+    * `cd ISLE`
 
-Your host server is now configured and ready to run ISLE.
+Your host server is now configured and ready to install ISLE.
 
 **Please continue by selecting your type of installation:**
 
@@ -114,29 +94,20 @@ Your host server is now configured and ready to run ISLE.
     - If you are not already `root`, enter either `sudo -s` or `sudo su` to become root.
 
 - Add the CentOS/RHEL epel-release package repository.
-```
-yum install -y epel-release
-```
+    - `yum install -y epel-release`
 
 - Install the following:
-```
-yum install -y openssl git htop ntp wget curl nano
-```
+    - `yum install -y openssl git htop ntp wget curl nano`
 
-```
-yum install -y yum-utils device-mapper-persistent-data lvm2
-```
+    - `yum install -y yum-utils device-mapper-persistent-data lvm2`
+
 ### Step 2: Install Docker
 
 - Add the Docker Repository.
-```
-yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-```
+    - `yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo`
 
 - Install Docker.
-```
-yum install -y docker-ce
-```
+    - `yum install -y docker-ce`
 
 ### Step 3: Install Docker-Compose
 
@@ -146,12 +117,9 @@ curl -L https://github.com/docker/compose/releases/download/1.23.1/docker-compos
 ```
 
 - Test the Installation.
-```
-docker-compose --version
-```
+    - `docker-compose --version`
 
-- **Example output:**
-`docker-compose version 1.23.1, build 1110ad01`
+- **Example output:** `docker-compose version 1.23.1, build 1110ad01`
 
 ### Step 4: Add Your User to the `docker` Group
 Allow your user to run Docker commands and to launch the entire ISLE stack.
@@ -159,9 +127,7 @@ Allow your user to run Docker commands and to launch the entire ISLE stack.
 - If you are still `root` (`whoami`), type `exit` to become your normal user.
 
 - Add yourself to the `docker` group.
-```
-sudo usermod -aG docker $USER
-```
+    - `sudo usermod -aG docker $USER`
 
 - Type `exit` and then reconnect (this allows your effective groups to update).
 
@@ -171,16 +137,12 @@ sudo usermod -aG docker $USER
 Please run these steps as your normal user (not `root`):
 
 * Clone the repository:
-```
-git clone https://github.com/Islandora-Collaboration-Group/ISLE.git
-```
+    * `git clone https://github.com/Islandora-Collaboration-Group/ISLE.git`
 
-- Change to the directory containing ISLE.
-```
-cd ISLE
-```
+* Change to the directory containing ISLE:
+    * `cd ISLE`
 
-Your host server is now configured and ready to run ISLE.
+Your host server is now configured and ready to install ISLE.
 
 **Please continue by selecting your type of installation:**
 
@@ -208,34 +170,31 @@ Git must be installed to get a copy (called a `clone`) of the current ISLE proje
     * The package will take 1-2 minutes to download.
     * Click the `Done` button.
 
-* If git is not installed and the prompt does not show, then use this tutorial to [Install Git on Mac OS X](https://www.atlassian.com/git/tutorials/install-git).
+* If git is not installed and there is no prompt to "Install Command Line Developer Tools", then use this tutorial to [Install Git on Mac OS X](https://www.atlassian.com/git/tutorials/install-git).
 
 * Enter the following to fix a potential issue with long filenames:
     * `git config --system core.longpaths true`
 
 ### Step 2: Install Docker for Mac
 
-* Open a browser and navigate to [Docker Desktop](https://www.docker.com/products/docker-desktop)
-
-* Click the `Download for Mac` button in the center of the page
-
-* Click the `Please Login to Download` button on the right of the page (click: `Sign In` or `Create Account`)
-
-* Click the `Get Docker` button on the right of the page
-
-* The `Docker.dmg` file should start to download. Check your `Downloads` directory
-
-* Double-click the `Docker.dmg` file. The file should open and mount in a new window / prompt.
-
-* As instructed within the prompt, drag and drop the whale icon to the right towards the `Applications` directory shortcut, a tiny green plus sign should appear, now let go from the mouse.
-
-* The application should start to copy data to the `Applications` directory, this process may take 1-5 mins depending on the speed of your hard-drive.
-
-* Launch the `Docker` application from the `Applications` directory
-
-* This process should may take 2 -5 mins depending on the speed of your hard-drive.
-
-* Once fully started, a whale icon will appear at top of the screen. If clicked, a dropdown should appear indicating that Docker is now running.
+* Click [Docker Desktop](https://www.docker.com/products/docker-desktop) and follow these instructions to download and install:
+    * Click the button: `Download for Mac`
+    * Click the button: `Please Login to Download`
+        * Click: `Sign In` or `Sign Up`
+    * Click the button: `Get Docker`
+        * The `Docker.dmg` file should start to download. Check your `Downloads` directory.
+    * Double-click the `Docker.dmg` file. The file should open and mount in a new window or prompt.
+    * As instructed within the prompt, drag and drop the whale icon to the right towards the `Applications` directory shortcut, a tiny green plus sign should appear, now let go from the mouse.
+    * The application should start to copy data to the `Applications` directory, this process may take 1-5 minutes depending on the speed of your hard-drive.
+* Important Docker installation notes:
+    * If Docker prompts you to restart the personal computer, please do so.
+    * If Docker prompts you to install additional Docker updates, please do so.
+    * If Docker prompts you (with a popup dialogue) to `Login with your Docker ID`, you may do so with your Docker.com account information, or you may skip it and close the window as Docker is already running; you do not need to login to use it.
+    * If Docker prompts you for access to your computer's filesystem, please do so, then close the dialogue window.
+* When the installation is finished:
+    * Launch the "Docker Desktop" application from the `Applications` directory
+    * This process should may take 2-5 minutes depending on the speed of your hard-drive.
+* When "Docker Desktop" is fully started, a whale icon will appear at top of the screen.  Clicking on this icon should show the message: "Docker Desktop is running".
 
 ### Step 3: Install Docker-Compose
 
@@ -247,22 +206,22 @@ Git must be installed to get a copy (called a `clone`) of the current ISLE proje
 Please run these steps as your normal user (not `root`):
 
 * Clone the repository:
-```
-git clone https://github.com/Islandora-Collaboration-Group/ISLE.git
-```
+    * `git clone https://github.com/Islandora-Collaboration-Group/ISLE.git`
 
-- Change to the directory containing ISLE.
-```
-cd ISLE
-```
+* Change to the directory containing ISLE:
+    * `cd ISLE`
+
 _To improve performance on Mac OSX:_
 
-* Open "docker-compose.yml" in a text editor and go to the the `apache` section
-* Under `volumes` find the following line:
+* Depending on your current desired type of installation, open one of the two following files in a text editor:
+    * `docker-compose.demo.yml`
+    * `docker-compose.local.yml`
+* Go to the the "apache" section, and under "volumes" find the following line:
     * `- ./mnt/html:/var/www/html`
-    * Change to: `- ./mnt/html:/var/www/html:cached`
+    * Change it to be:
+    * `- ./mnt/html:/var/www/html:cached`
 
-Your host server is now configured and ready to run ISLE.
+Your host server is now configured and ready to install ISLE.
 
 **Please continue by selecting your type of installation:**
 
@@ -287,12 +246,12 @@ Your host server is now configured and ready to run ISLE.
         * Download: [Git for Windows](https://gitforwindows.org/)
         * Click `Download`; `Save` this file to your Desktop; `double-click` that file to install; then click `Yes` to the prompt.
         * Click `Next` and accept ALL of the installer's default selections, with the one following exception:
-            * **Choosing the default editor used by Git**
-            * Please select your preferred text editor (we recommend ATOM).
-            * If you selected ATOM and do not yet have it installed, please install [ATOM](https://atom.io/) now, then continue below.
+            * **Choosing the default editor used by Git: Which editor would you like Git to use?**
+            * Select your preferred text editor (we recommend "Atom").
+            * If you selected "Atom" and do not yet have it installed, please [install Atom](https://atom.io/) now, then continue below.
 * Press the Windows key
 * Type `Git Bash`
-* RIGHT-CLICK `Git Bash` to open it; select `More`; select `Run as administrator`; then click `Yes` to the prompt.
+* RIGHT-CLICK the "Git Bash" app to open it; select `Run as administrator`; then click `Yes` to the prompt.
 * In the Git Bash terminal:
     * Enter: `git --version`
     * The above command will output the installed version number. This confirms that git is properly installed.
@@ -306,18 +265,22 @@ Your host server is now configured and ready to run ISLE.
 
 **Important: Docker requires Windows Professional or Windows Enterprise**
 
-* Download: [Docker Desktop for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
-* Click the button: `Please Login to Download`
-    * Click: `Sign In` or `Sign Up`
-* Click the button: `Get Docker`
-    * `Save` this file to your Desktop; `double-click` that file to install; then click `Yes` to the prompt.
-* Click `OK` or `Next` and accept ALL of the installer's default selections.
-* You will be required to `Close and log out` when the installation is complete.
-* The computer will reboot; please sign in.
-* If prompted to enable `Hyper-V and Containers features`, click `OK`.
-* If prompted with a Docker popup dialogue to `Login with your Docker ID`, you may do so with your Docker.com account information, or you may simply close the window.  Docker is running and you do not need to login to use it.
-
-* Once fully started, a whale icon will appear in the notification area. If clicked, a dropdown should appear indicating that Docker is now running.
+* Click [Docker Desktop for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) and follow these instructions to download and install:
+    * Click the button: `Please Login to Download`
+        * Click: `Sign In` or `Sign Up`
+    * Click the button: `Get Docker`
+        * `Save` this file to your Desktop; `double-click` that file to install; then click `Yes` to the prompt.
+    * Click `OK` or `Next` and accept ALL of the installer's default selections.
+* Important Docker installation notes:
+    * If Docker prompts you to restart the personal computer, please do so.
+    * If Docker prompts you to install additional Docker updates, please do so.
+    * If Docker prompts you to enable `Hyper-V and Containers features`, click `OK`.
+    * If Docker prompts you (with a popup dialogue) to `Login with your Docker ID`, you may do so with your Docker.com account information, or you may skip it and close the window as Docker is already running; you do not need to login to use it.
+* When the installation is finished:
+    * Press the Windows key
+    * Type `Docker Desktop`
+    * Click the "Docker Desktop" app to open it
+* When "Docker Desktop" is fully started, a whale icon will appear in the Windows "Notification Area". Hovering over this icon should show the message: "Docker Desktop is running".
 
 * Enable Docker Shared Drives
     * Right-click on the Docker whale icon
@@ -325,6 +288,7 @@ Your host server is now configured and ready to run ISLE.
     * Select "Shared Drives"
     * Check the box for your local "C" drive
     * Click "Apply"
+    * If Docker prompts you for access to your computer's filesystem, please do so, then close the dialogue window.
 
 ### Step 3: Install Docker-Compose
 
@@ -339,23 +303,23 @@ Your host server is now configured and ready to run ISLE.
     * `cd ~`
 * Clone the repository:
     * `git clone https://github.com/Islandora-Collaboration-Group/ISLE.git`
-* Change to the directory containing ISLE.
+* Change to the directory containing ISLE:
     * `cd ISLE`
-* Enter the following to display the present working directory
+* Enter the following command to display the present working directory (full path) of your ISLE project.
     * `pwd`
-* Note that the output represents the full path of your ISLE project. You will use this path in the next step.
+* You will use this full path (output of the above command) in the next step.
     * **Example output:** "/c/Users/somebody/ISLE"
 
-#### Edit "demo.env" and "local.env"
+#### Edit "demo.env" or "local.env"
 
 * Press the Windows key.
 * Type `Notepad`.
 * In the search results, RIGHT-CLICK `Notepad`, select `Run as administrator`, and enter `Yes` to prompt.
 * Select `File -> Open`
-* At top of dialog window, go to your ISLE project (see full path in previous step).
+* At top of dialog window, navigate to your ISLE project (refer to the "full path" displayed in previous step).
 * At right side of dialog window, use the dropdown menu to change `Text Documents (*.txt)` to `All Files (*.*)`
     * (Optional: see [How to show hidden files](https://support.microsoft.com/en-us/help/4028316/windows-view-hidden-files-and-folders-in-windows-10)).
-* Select a file based on your desired type of installation: `demo.env` or `local.env`
+* Select the file based on your current desired type of installation: `demo.env` or `local.env`
     * Click `Open`.
 * Find the following line:
     * `# COMPOSE_CONVERT_WINDOWS_PATHS=1`
@@ -363,7 +327,7 @@ Your host server is now configured and ready to run ISLE.
     * `COMPOSE_CONVERT_WINDOWS_PATHS=1`
 * Click `File > Save`, and then `File -> Exit`.
 
-Your host server is now configured and ready to run ISLE.
+Your host server is now configured and ready to install ISLE.
 
 **Please continue by selecting your type of installation:**
 

--- a/docs/install/install-demo-edit-hosts-file.md
+++ b/docs/install/install-demo-edit-hosts-file.md
@@ -1,4 +1,4 @@
-# Demo ISLE Installation: Edit the "/etc/hosts" File
+# Demo or Local: Edit the "/etc/hosts" File
 
 Edit the `/etc/hosts` file to view ISLE locally on a personal computer browser.
 
@@ -13,47 +13,56 @@ Edit the `/etc/hosts` file to view ISLE locally on a personal computer browser.
 
 ## Mac or Ubuntu Using Docker
 
-* **Docker For Mac** If you are using Docker For Mac, then use the IP address of `127.0.0.1` to resolve to `localhost` and to the `isle.localdomain localhost isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain` domain names
-
-* Open a terminal on the personal computer
+* Open a terminal on the personal computer.
 
 * Enter: `sudo nano /etc/hosts`
     * _For endusers familiar with editing files on the command line, vim, emacs or alternative tools can be used in lieu of nano_
 
 * Enter the personal computer end user password
 
-* Find the `127.0.0.1 localhost` entry in the `/etc/hosts` file.
-* Go to end of same line, add one space, and then paste the following:
+* Select the appropriate installation scenario, below:
+    1. **For Demo ISLE Installations:**
+        * Find the `127.0.0.1 localhost` entry in the `/etc/hosts` file.
+        * Go to end of same line, add one space, and then paste the following:
+        * `isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain`
 
-    * `isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain`
+    2. **For Local ISLE Installations:**
+        * Find the `127.0.0.1 localhost` entry in the `/etc/hosts` file.
+        * Go to end of same line, add one space, and then paste the following, substituting `yourprojectnamehere` with your preferred name:
+        * `yourprojectnamehere.localdomain admin.yourprojectnamehere.localdomain images.yourprojectnamehere.localdomain portainer.yourprojectnamehere.localdomain`
+        * Note: While not required, it is perfectly okay to have multiple lines so as to define both the Demo and the Local ISLE installations, as shown in the example below:
+```
+127.0.0.1 localhost isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain
+127.0.0.1 localhost yourprojectnamehere.localdomain admin.yourprojectnamehere.localdomain images.yourprojectnamehere.localdomain portainer.yourprojectnamehere.localdomain
+```
 
-  * Enter `Cntrl` and the letter `o` together to write the changes to the file.
+* Enter `Cntrl` and the letter `o` together to write the changes to the file.
 
-  * Enter `Cntrl` and the letter `x` together to exit the file.
+* Enter `Cntrl` and the letter `x` together to exit the file.
 
-**Please return to [Demo ISLE Installation](../install/install-demo.md#step-2-launch-process) and continue with _Step 2: Launch Process_.**
+**Please return to the appropriate installation:**
+
+* [Demo ISLE Installation](../install/install-demo.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: New Site](../install/install-local-new.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md#step-1-edit-etchosts-file) and continue with _Step 2_.
 
 ---
 
 ## Mac or Ubuntu Desktop Using Virtualbox VM (non-Vagrant)
 
-* From the instructions in setting up the Virtualbox VM on your OS (MacOS, Ubuntu or Windows), the IP used to setup the Host-Only network was `10.10.10.130`
+* Note: From the instructions in setting up the Virtualbox VM on your MacOS or Ubuntu, the IP used to setup the Host-Only network was `10.10.10.130`.
 
-* Add the value of `10.10.10.130 isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain` to the personal computer's `/etc/hosts` file.   
+* Open a terminal on the personal computer.
 
-* For endusers running MacOS and Ubuntu Desktop:
+* Enter: `sudo nano /etc/hosts`
+   * _For endusers familiar with editing files on the command line, vim, emacs or alternative tools can be used in lieu of nano_
 
-   * Open a terminal on the personal computer
+* Enter the personal computer end user password
 
-   * Enter: `sudo nano /etc/hosts`
-       * _For endusers familiar with editing files on the command line, vim, emacs or alternative tools can be used in lieu of nano_
+* Add the values below the `127.0.0.1` entry in the `/etc/hosts` file.
 
-   * Enter the personal computer end user password
-
-   * Add the values below the `127.0.0.1` entry in the `/etc/hosts` file.
-
-       * `10.10.10.130 localhost isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain`  
-       * **Example:**
+   * `10.10.10.130 localhost isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain`  
+   * **Example:**
 
 ```
         127.0.0.1 localhost
@@ -64,7 +73,11 @@ Edit the `/etc/hosts` file to view ISLE locally on a personal computer browser.
 * Enter `Cntrl` and the letter `o` together to write the changes to the file.
 * Enter `Cntrl` and the letter `x` together to exit the file.
 
-**Please return to [Demo ISLE Installation](../install/install-demo.md#step-2-launch-process) and continue with _Step 2: Launch Process_.**
+**Please return to the appropriate installation:**
+
+* [Demo ISLE Installation](../install/install-demo.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: New Site](../install/install-local-new.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md#step-1-edit-etchosts-file) and continue with _Step 2_.
 
 ---
 
@@ -72,27 +85,41 @@ Edit the `/etc/hosts` file to view ISLE locally on a personal computer browser.
 
 * For endusers running Windows 10:
 
-    * Press the Windows key.
+* Press the Windows key.
 
-    * Type `Notepad`.
+* Type `Notepad`.
 
-    * In the search results, RIGHT-CLICK `Notepad`, select `Run as administrator`, and enter `Yes` to prompt.
+* In the search results, RIGHT-CLICK `Notepad`, select `Run as administrator`, and enter `Yes` to prompt.
 
-    * Select `File -> Open`.
+* Select `File -> Open`.
 
-    * In the `File name:` input box, paste this path `C:\Windows\System32\Drivers\etc\hosts`.
+* In the `File name:` input box, paste this path `C:\Windows\System32\Drivers\etc\hosts`.
 
-    * Click `Open`.
+* Click `Open`.
 
-    * Find the `127.0.0.1 localhost` entry and uncomment it (by deleting the preceding `#` character).
-
-    * Go to end of same line, add one space, and then paste the following:
-
+* Select the appropriate installation scenario, below:
+    1. **For Demo ISLE Installations:**
+        * Find the `127.0.0.1 localhost` entry and uncomment it (by deleting the preceding `#` character).
+        * Go to end of same line, add one space, and then paste the following:
         * `isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain`
 
-    * Click `File > Save`, and then `File -> Exit`.
+    2. **For Local ISLE Installations:**
+        * Find the `127.0.0.1 localhost` entry and uncomment it (by deleting the preceding `#` character).
+        * Go to end of same line, add one space, and then paste the following, substituting `yourprojectnamehere` with your preferred name:
+        * `yourprojectnamehere.localdomain admin.yourprojectnamehere.localdomain images.yourprojectnamehere.localdomain portainer.yourprojectnamehere.localdomain`
+        * Note: While not required, it is perfectly okay to have multiple lines so as to define both the Demo and the Local ISLE installations, as shown in the example below:
+```
+127.0.0.1 localhost isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain
+127.0.0.1 localhost yourprojectnamehere.localdomain admin.yourprojectnamehere.localdomain images.yourprojectnamehere.localdomain portainer.yourprojectnamehere.localdomain
+```
 
-**Please return to [Demo ISLE Installation](../install/install-demo.md#step-2-launch-process) and continue with _Step 2: Launch Process_.**
+* Click `File > Save`, and then `File -> Exit`.
+
+**Please return to the appropriate installation:**
+
+* [Demo ISLE Installation](../install/install-demo.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: New Site](../install/install-local-new.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md#step-1-edit-etchosts-file) and continue with _Step 2_.
 
 ---
 
@@ -100,22 +127,26 @@ Edit the `/etc/hosts` file to view ISLE locally on a personal computer browser.
 
 * For endusers running Windows 10:
 
-    * Press the Windows key.
+* Press the Windows key.
 
-    * Type `Notepad`.
+* Type `Notepad`.
 
-    * In the search results, RIGHT-CLICK `Notepad`, select `Run as administrator`, and enter `Yes` to prompt.
+* In the search results, RIGHT-CLICK `Notepad`, select `Run as administrator`, and enter `Yes` to prompt.
 
-    * Select `File -> Open`.
+* Select `File -> Open`.
 
-    * In the `File name:` input box, paste this path `C:\Windows\System32\Drivers\etc\hosts`.
+* In the `File name:` input box, paste this path `C:\Windows\System32\Drivers\etc\hosts`.
 
-    * Click `Open`.
+* Click `Open`.
 
-    * Find the `127.0.0.1` entry, then paste the following values below that line:
+* Find the `127.0.0.1` entry, then paste the following values below that line:
 
-        * `10.10.10.130 isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain`  
+    * `10.10.10.130 isle.localdomain admin.isle.localdomain images.isle.localdomain portainer.isle.localdomain`  
 
-    * Click `File > Save`, and then `File -> Exit`.
+* Click `File > Save`, and then `File -> Exit`.
 
-**Please return to [Demo ISLE Installation](../install/install-demo.md#step-2-launch-process) and continue with _Step 2: Launch Process_.**
+**Please return to the appropriate installation:**
+
+* [Demo ISLE Installation](../install/install-demo.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: New Site](../install/install-local-new.md#step-1-edit-etchosts-file) and continue with _Step 2_.
+* [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md#step-1-edit-etchosts-file) and continue with _Step 2_.

--- a/docs/install/install-demo.md
+++ b/docs/install/install-demo.md
@@ -10,19 +10,21 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * This Demo ISLE Installation is intended for a personal computer.
 
-* You will be using ISLE version `1.2.0` or higher
+* You will be using ISLE version **1.2.0** or higher.
 
-* You are using Docker-compose `1.24.0` or higher
+* You are using Docker-compose **1.24.0** or higher.
 
 * You have already git cloned the ISLE Project to your personal computer.
 
-* **For Microsoft Windows:** You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git Bash" as your command line interface; this behaves similarly to LINUX and UNIX environments.
+* **For Microsoft Windows:**
+    * You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git Bash" as your command line interface; this behaves similarly to LINUX and UNIX environments.
+    * In the "demo.env" file, you must uncomment the line "# COMPOSE_CONVERT_WINDOWS_PATHS=1". (See Software Dependencies: [Edit "demo.env" or "local.env"](../install/host-software-dependencies.md#edit-demoenv-or-localenv))
 
 ---
 
 ## Step 1: Edit "/etc/hosts" File
 
-Enable the Demo ISLE Installation to be viewed locally on personal computer browser as: `https://isle.localdomain`.
+Enable the Demo ISLE Installation to be viewed locally on a personal computer browser as: `https://isle.localdomain`.
 
 * Please use these instructions to [Edit the "/etc/hosts" File](../install/install-demo-edit-hosts-file.md).
 
@@ -75,7 +77,7 @@ This process may take 10-20 minutes (_depending on system and internet speeds_)
 
 * You should see a lot of green [ok] messages.
 * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
-* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
+* **Proceed only after this message appears:** "Done. 'all' cache was cleared."
 
 ---
 
@@ -120,7 +122,7 @@ Once you are ready, you may progress to either:
 ---
 
 ## Additional Resources
-* [Demo ISLE Installation: Resources](../install/install-demo-resources.md) contains Docker container passwords and URLs for administrator tools.
+* [Demo ISLE Installation: Resources](../install/install-demo-resources.md) contains Docker container passwords and URLs for administrator testing.
 * [ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/install-environments.md
+++ b/docs/install/install-environments.md
@@ -1,20 +1,20 @@
 # Overview: ISLE Installation Environments
 
-As of the ISLE `1.2.0` release, ISLE now has the option to use clearly defined but different environments based on enduser's needs. Depending on the environment choice, additional configuration changes will need to be made to ISLE configuration files, domain names, etc. When an ISLE enduser is ready to progress past using the default Demo environment, it is recommended that their learning path and workflow proceed in this suggested order.
+As of the ISLE `1.2.0` release, ISLE has the option to use clearly defined but different environments based on enduser's needs. Depending on the environment choice, additional configuration changes will need to be made to ISLE configuration files, domain names, etc. We recommend that you install ISLE using the workflow and suggested order below.
 
-* **Demo** - *Default* - Used for trying out ISLE for the first time, having a sandbox for tests etc
+* **Demo** (Default) - Used for trying out ISLE for the first time, having a sandbox for tests etc
 
-* **Local** - Used for Drupal site development, more extensive metadata, Solr and Fedora development work on a personal computer
+* **Local** - Used for Drupal site development, more extensive metadata, Solr and Fedora development work on a Local personal computer
 
-* **Staging** - Used for remote (non-local / cloud) hosting of a Staging site. Islandora Drupal site code here is almost finished but viewed privately prior to pushing to public Production. Fedora data might have tests collections.
+* **Staging** - Used for remote (non-local or cloud) hosting of a Staging site. Islandora Drupal site code here is almost finished but viewed privately prior to pushing to public Production. Fedora data might have tests collections.
 
-* **Production** - Used for remote (non-local / cloud) hosting of a Production site. Site and collections are public and accessible to the world. Drupal site code is finished, functional and polished. Fedora data has full non test collections. Test collections are not recommended here.
+* **Production** - Used for remote (non-local or cloud) hosting of a Production site. Site and collections are public and accessible to the world. Drupal site code is finished, functional and polished. Fedora data has full non test collections. Test collections are not recommended here.
 
 * **Test** - Used by ISLE Maintainers for testing ISLE releases, pull releases and ISLE development, etc.
 
 ## ISLE Project Structure
 
-ISLE endusers will make the appropriate changes to the values found in the ISLE project `.env` to be able to define and launch their working environment. This `.env` should then have values that point to an corresponding `docker-compose.*.yml` file. As you can see from the root of the ISLE project now (ISLE version 1.2.0+), there additional `docker-compose` files that match an environment as well as additional named `.env` files. Below is a potential outline of all the files that an ISLE enduser might have to edit, change or add as a result of choosing an environment. (_Subject to change_)
+The ISLE project `.env` file enables you to be define and launch a variety of ISLE environments. On each ISLE environment, you will edit the `.env` file to point to a corresponding `docker-compose.*.yml` file configured for that environment. The root of the ISLE project (ISLE version 1.2.0+) comes with multiple, pre-configured examples of `docker-compose` and `.env` files to match the variety of environments shown below. The outline below lists the files that you may have to edit, change or add to support each ISLE environment. 
 
 * `.env` - 
   
@@ -77,9 +77,9 @@ ISLE endusers will make the appropriate changes to the values found in the ISLE 
 
 ---
 
-## ISLE Environments `.env` reference
+## ISLE Environments ".env" reference
 
-Please note this section is for reference only when are ISLE endusers making changes. In some cases, environment descriptions and settings are suggestions not actual values. ISLE endusers can copy values to the Activated ISLE environment section within the ISLE project `.env`.
+This reference includes a combination of suggestions and actual values. You may use these environment descriptions or settings in each of your corresponding ISLE project `.env` files.
 
 ### Demo
 
@@ -115,7 +115,7 @@ COMPOSE_FILE=docker-compose.local.yml # (Mandatory) The docker-compose file used
 
 ### Staging
 
-* Used for remote (non-local / cloud) hosting of a Staging site. Code here is almost finished but viewed privately prior to pushing to public Production.
+* Used for remote (non-local or cloud) hosting of a Staging site. Code here is almost finished but viewed privately prior to pushing to public Production.
 
 * Please read through the `docker-compose.staging.yml` file as there are bind mount points that need to be configured on the host machine, to ensure data persistence. There are suggested bind mounts that the end-user can change to fit their needs or they can setup additional volumes or disks to match the suggestions.
 
@@ -134,7 +134,7 @@ COMPOSE_FILE=docker-compose.staging.yml # (Mandatory) The docker-compose file us
 
 ### Production
 
-* Used for remote (non-local / cloud) hosting of a Production site. Site and collections are public and accessible to the world.
+* Used for remote (non-local or cloud) hosting of a Production site. Site and collections are public and accessible to the world.
 
 * Please read through the `docker-compose.production.yml` file as there are bind mount points that need to be configured on the host machine, to ensure data persistence. There are suggested bind mounts that the end-user can change to fit their needs or they can setup additional volumes or disks to match the suggestions.
 

--- a/docs/install/install-local-migrate.md
+++ b/docs/install/install-local-migrate.md
@@ -1,16 +1,16 @@
 # Local ISLE Installation: Migrate Existing Islandora Site
 
-_Expectations:  It takes an average of **60-120 minutes** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
-This `Local` ISLE Installation builds a local environment for the express purpose of migrating a previously existing Islandora site onto the ISLE platform. If you need to build a brand new local development site, please **stop** and use the [Local ISLE Installation: New Site](../install/install-local-new.md) instructions instead.
+This Local ISLE Installation builds a local environment for the express purpose of migrating a previously existing Islandora site onto the ISLE platform. If you need to build a brand new local development site, please **stop** and use the [Local ISLE Installation: New Site](../install/install-local-new.md)  instead.
 
-This `Local` ISLE Installation will use a copy of a currently running Production Islandora Drupal website and an empty Fedora repository for endusers to test migration to ISLE and do site development and design with the end goal of deploying to ISLE Staging and Production environments for public use. The final goal would be to cut over from the existing non-ISLE Production and Staging servers to their new ISLE counterparts.
+This Local ISLE Installation will use a copy of a currently running Production Islandora Drupal website and an empty Fedora repository for endusers to test migration to ISLE and do site development and design with the end goal of deploying to ISLE Staging and Production environments for public use. The final goal would be to cut over from the existing non-ISLE Production and Staging servers to their new ISLE counterparts.
 
-This `Local` ISLE Installation will allow you to locally view this site in your browser with the domain of your choice (**Example:** `https://yourprojectnamehere.localdomain`), instead of being constrained to the Demo url (`https://isle.localdomain`).
+This Local ISLE Installation will allow you to locally view this site in your browser with the domain of your choice (**Example:** "https://yourprojectnamehere.localdomain"), instead of being constrained to the Demo URL ("https://isle.localdomain").
 
-This document has directions on how you can check in newly created ISLE code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation offers an overview of the ISLE structure, the associated files, and what values ISLE endusers should use for the `.env`, `local.env`, etc.
+This document has directions on how you can save newly created ISLE code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation offers an overview of the ISLE structure, the associated files, and what values ISLE endusers should use for the ".env", "local.env", etc.
 
-This document **does not** have directions on how you can check in previously existing Islandora Drupal code into a git repository and assumes this step has already happened. The directions below will explain how to clone Islandora Drupal code from a previously existing Islandora Drupal git repository that should already be accessible to you.
+This document **does not** have directions on how you can save previously existing Islandora Drupal code into a git repository and assumes this step has already happened. The directions below will explain how to clone Islandora Drupal code from a previously existing Islandora Drupal git repository that should already be accessible to you.
 
 Please post questions to the public [Islandora ISLE Google group](https://groups.google.com/forum/#!forum/islandora-isle), or subscribe to receive emails. The [Glossary](../appendices/glossary.md) defines terms used in this documentation.
 
@@ -18,28 +18,30 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * This Local ISLE installation expects that an existing Production Islandora Drupal site will be imported on a personal computer for further ISLE migration testing, Drupal theme development, ingest testing, etc.
 
-* You will be using ISLE version `1.2.0` or higher
+* You will be using ISLE version **1.2.0** or higher.
 
-* You are using Docker-compose `1.24.0` or higher
+* You are using Docker-compose **1.24.0** or higher.
 
 * You have git installed on your personal computer.
 
-* You have a previously existing private Islandora Drupal git repository
+* You have a previously existing private Islandora Drupal git repository.
 
 * You have access to a private git repository in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc.
     * If you do not, please contact your IT department for git resources, or else create an account with one of the above providers.
     * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files. **DO NOT** share these git repositories publicly.
 
 * **For Microsoft Windows:**
-    * You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git Bash" as your command line interface; this behaves similarly to LINUX and UNIX environments. Git for Windows also installs `openssl.exe` which will be needed to generate self-signed SSL certs. (Note: Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.)
+    * You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git Bash" as your command line interface; this behaves similarly to LINUX and UNIX environments. Git for Windows also installs "openssl.exe" which will be needed to generate self-signed SSL certs. (Note: Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.)
     * Set your text editor to use UNIX style line endings for files. (Text files created on DOS/Windows machines have different line endings than files created on Unix/Linux. DOS uses carriage return and line feed ("\r\n") as a line ending, which Unix uses just line feed ("\n").)
+    * In the "local.env" file, you must uncomment the line "# COMPOSE_CONVERT_WINDOWS_PATHS=1". (See Software Dependencies: [Edit "demo.env" or "local.env"](../install/host-software-dependencies.md#edit-demoenv-or-localenv))
 
 ---
 
 ## Index of Instructions
 
 * Step 0: Copy Production Data to Your Personal Computer
-* Step 1: Edit "/etc/hosts" File
+* Step 1: Choose a Project Name
+* Step 1.5: Edit "/etc/hosts" File
 * Step 2: Setup Git for the ISLE Project
 * Step 3: Git Clone the Production Islandora Drupal Site Code
 * Step 4: Edit the ".env" File to Change to the Local Environment
@@ -70,21 +72,21 @@ Be sure to run a backup of any current non-ISLE systems prior to copying or expo
 
 * Drupal website databases can have a multitude of names and conventions. Confer with the appropriate IT departments for your institution's database naming conventions.
 
-* Recommended that the production databases be exported using the `.sql` /or `.gz` file formats e.g. `prod_drupal_site_082019.sql.gz` for better compression and minimal storage footprint.
+* Recommended that the production databases be exported using the ".sql" /or ".gz" file formats (e.g. "prod_drupal_site_082019.sql.gz") for better compression and minimal storage footprint.
 
 * If the end user is running multi-sites, there will be additional databases to export.
 
-* Do not export the `fedora3` database or any system tables (such as `information_schema`, `performance_schema`, `mysql`)
+* Do not export the "fedora3" database or any system tables (such as "information_schema", "performance_schema", "mysql")
 
-* If possible, on the production Apache webserver, run `drush cc all` from the command line on the production server in the `/var/www/html` directory PRIOR to any db export(s). Otherwise issues can occur on import due to all cache tables being larger than `innodb_log_file_size` allows
+* If possible, on the production Apache webserver, run `drush cc all` from the command line on the production server in the `/var/www/html` directory PRIOR to any db export(s). Otherwise issues can occur on import due to all cache tables being larger than "innodb_log_file_size" allows
 
 #### Export the Production MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current Production Islandora Drupal site in use and copy it to your personal computer (local) in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your Production site.
 
 * If you are not comfortable or familiar with performing these actions, we recommend that you instead work with your available IT resources to do so.
-    * You can use a MySQL GUI client for this process or if you have command line access to the MySQL database server
-    `mysqldump -u username -p database_name > prod_drupal_site_082019.sql`
+    * To complete this process, you may use a MySQL GUI client or, if you have command line access to the MySQL database server, you may run the following command, substituting your actual user and database names:
+    * **Example:** `mysqldump -u username -p database_name > prod_drupal_site_082019.sql`
     * Copy this file down to your personal computer.
 
 ### Fedora Hash Size (Conditional)
@@ -107,7 +109,7 @@ Bind mount in existing transforms and schemas  to override ISLE settings with yo
 
 **WARNING** _This approach assumes you are running Solr 4.10.x.; **only attempt** if you are running that version on Production._
 
-* Copy these current production files and directory to your personal computer in an appropriate location.
+* Copy these current Production files and directory to your personal computer in an appropriate location.
     * Solr `schema.xml`
     * GSearch `foxmltoSolr.xslt` file
     * GSearch `islandora_transforms`
@@ -143,41 +145,54 @@ Bind mount in existing transforms and schemas  to override ISLE settings with yo
 
 ---
 
-## Step 1: Edit "/etc/hosts" File
+## Step 1: Choose a Project Name
 
-Enable the Local ISLE Installation to be viewed locally on personal computer browser as: e.g. `https://yourprojectnamehere.localdomain`.
+Please choose a project name (concatenated, with no spaces) that describes your institution or your collection platform. You will substitute in your preferred project name whenever the documentation refers to "yourprojectnamehere". (Be creative. Some real-life examples include: arminda, dhinitiative, digital, digitalcollections, digitallibrary, unbound, etc.)
+
+---
+
+## Step 1.5: Edit "/etc/hosts" File
+
+Enable the Local ISLE Installation to be viewed locally on a personal computer browser using "yourprojectnamehere" (e.g. "https://yourprojectnamehere.localdomain").
 
 * Please use these instructions to [Edit the "/etc/hosts" File](../install/install-demo-edit-hosts-file.md).
-
-* Replace `isle` or `yourprojectnamehere` with your domain or project name: e.g. `yourprojectnamehere.localdomain`
 
 ---
 
 ## Step 2: Setup Git for the ISLE Project
 
-**Please note:** The commands given below are for command line usage of git. GUI based clients such as the [SourceTree App](https://www.sourcetreeapp.com/) may be easier for endusers to use for the git process.
+**Please note:** The commands given below are for command line usage of git. (GUI based clients such as the [SourceTree App](https://www.sourcetreeapp.com/) may be easier for endusers to use for the git process.)
 
-Within your git repository provider / hoster (e.g [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com)), create these two new empty git repositories, if they do not already exist:
+Each "suggested git repository name" (below) serves to clearly name and distinguish your ISLE code from your Islandora code. It's very important to understand that these are two separate code repositories, and not to confuse them.
 
-    1. ISLE project configuration (e.g. `yourprojectnamehere-isle`)
-    2. Islandora Drupal code (e.g. `yourprojectnamehere-islandora`)
+Create the following two new, empty, private git repositories (if they do not already exist) within your git repository hosting service (e.g [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com)):
 
-The git project name can be your institution name or the name of the collections you plan to deploy; your choice entirely. A very clear distinction between the ISLE and Islandora code should be made in the repository name. Do not confuse or label Islandora Drupal site code as ISLE and vice-versa.
+1. ISLE project configuration repository
+    * **Suggested git repository name:** `yourprojectnamehere-isle`
+    * This Git repository will hold your copy of the ISLE code along with your environment-specific customizations. Storing this in a private repository and following the workflow below will save you a lot of time and confusion.
+2. Islandora Drupal code repository
+    * **Suggested git repository name:** `yourprojectnamehere-islandora`
+    * This Git repository will hold your copy of the Islandora Drupal code along with your site specific customizations. Storing this in a private repository and following the workflow below will save you a lot of time and confusion.
 
-Clone this newly created ISLE project to your personal computer
+Clone this newly created ISLE project to your personal computer:
 
-    * Open a `terminal` (Windows: open `Git Bash`)
-    * Navigate to a directory that will house your new ISLE project directory using the `cd` command.
-    * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git`
+* Open a `terminal` (Windows: open `Git Bash`)
+* Navigate to a directory that will house your new ISLE project directory using the `cd` command.
+* **Example:** `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git`
 
-* Navigate to the directory created by the clone operation:
+* Navigate to the directory that was just created by the clone operation:
 
     * `cd /path/to/your/repository`
 
-* Add the ICG ISLE git repository as a git upstream. (_The code shown below is a real path and command_.)
+* Add the ICG ISLE git repository as a git upstream:
 
     * `git remote add icg-upstream https://github.com/Islandora-Collaboration-Group/ISLE.git`
-    * You can check by running this command: `git remote -v`  
+
+* View your remotes:
+
+    * `git remote -v`
+
+* You should now see the following:
 
 ```bash  
 icg-upstream	https://github.com/Islandora-Collaboration-Group/ISLE.git (fetch)
@@ -190,40 +205,46 @@ origin	https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-i
 
     * `git fetch icg-upstream`
 
-* Pull down the ICG ISLE `master` branch into your local project's `master` branch
+* Pull down the ICG ISLE "master" branch into your local project's "master" branch
 
     * `git pull icg-upstream master`
-    * If you `ls -lha` in this directory, you should now see a listing of the code you now have.
+
+* View the ISLE code you now have in this directory:
+
+    * `ls -lha`
 
 * Push this code to your online git provider ISLE
 
     * `git push -u origin master`
+    * This will take 2-5 minutes depending on your internet speed.
 
-    * This will take 2-5 mins depending on your internet speed.
-
-* Now you have the current ISLE project code checked into git as foundation to make changes specific to your local and project needs. You'll use this git "icg-upstream" process in the future to pull updates and releases from the main ISLE project.
+* Now you have the current ISLE project code checked into git as a foundation to make changes specific to your local and project needs. You'll use this git "icg-upstream" process in the future to pull updates and releases from the main ISLE project.
 
 ### Step 2a: Add Customizations from "Step 0" to the Git Workflow
 
 This step is intended for users who followed either the "**Intermediate**" or "**Advanced**" migration options in "Step 0" above.  If you choose the **Easy** migration option you may safely skip `Step 2a`.
 
-In your local `ISLE` directory (`cd /path/to/your/repository`) create new directories under `./config` to hold the Solr and GSearch files you retrieved in "Step 0".  Generally this can be done like so:
+Navigate to your local "ISLE" directory
+
+* `cd /path/to/your/repository`
+
+Create new directories under "./config" to hold the Solr and GSearch files you retrieved in "Step 0".  Do the following::
 
 ```
 mkdir -p ./config/solr
 mkdir -p ./config/fedora/gsearch
 ```
 
-* Copy your `schema.xml` file from "Step 0" into the new `./config/solr/` directory.
+* Copy your "schema.xml" file from "Step 0" into the new "./config/solr/" directory.
 
-* Copy your `foxmltoSolr.xslt` file and `islandora_transforms` directory from "Step 0" into the `config/fedora/gsearch/` directory.
+* Copy your "foxmltoSolr.xslt" file and "islandora_transforms" directory from "Step 0" into the "config/fedora/gsearch/" directory.
 
-* Add a new line in the Solr volumes section of your `docker-compose.local.yml`  
+* Add a new line in the Solr volumes section of your "docker-compose.local.yml"  
 ```
   - config/solr/schema.xml:/usr/local/solr/collection1/conf/schema.xml`  
 ```
 
-* Add new lines in the Fedora volumes section of your `docker-compose.local.yml`  
+* Add new lines in the Fedora volumes section of your "docker-compose.local.yml"  
 ```
   - ./config/fedora/gsearch/islandora_transforms:/usr/local/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms
   - ./config/fedora/gsearch/foxmlToSolr.xslt:/usr/local/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/foxmlToSolr.xslt
@@ -242,15 +263,15 @@ This step assumes you have an existing Islandora Drupal site checked into a git 
 _Using the same open terminal:_
 
 * Create a location outside of your ISLE directory where your Islandora Drupal site code will be stored.
-  While you may create this location anywhere, we suggest that you put it at the same level as your existing ISLE directory.
-    * From your ISLE directory:
-        * `cd ..`
-        * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
-        * Example: The above process created a folder named "yourprojectnamehere-islandora"
-* Now update the `docker-compose.local.yml` in the ISLE repository to create a bind-mount to the Islandora Drupal site code:
+  While you may create this location anywhere, we suggest that you put it at the same level as your existing ISLE directory. From your ISLE directory, go up one level:
+    * `cd ..`
+    * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
+    * **Example:** The above process created a folder named "yourprojectnamehere-islandora"
+* Now update the "docker-compose.local.yml" in the ISLE repository to create a bind-mount to the Islandora Drupal site code:
     * Search for "apache:"
     * Find the sub-section called "volumes:"
-    * Find this line: "- ./data/apache/html:/var/www/html:cached"
+    * Find this line:
+        * "- ./data/apache/html:/var/www/html:cached"
     * Edit the above line to be like this:
         * ` - ../yourprojectnamehere-islandora:/var/www/html:cached`
 * Your Production Islandora site code is now configured to be used in this local setup.
@@ -259,35 +280,30 @@ _Using the same open terminal:_
 
 ## Step 4: Edit the ".env" File to Change to the Local Environment
 
-Open a `terminal` (Windows: open `Git Bash`)
+* Navigate to your ISLE project directory.
 
-* Navigate to your ISLE project directory. (You may already be in this directory if you are coming from the [Software Dependencies](../install/host-software-dependencies.md).)
+* Open the ".env" file in a text editor.
 
-* Open `.env` file by running: `nano .env`
-      * _For endusers familiar with editing files on the command line, vim, emacs or alternative tools can be used in lieu of nano_
-
-* Change only the following lines in the `.env` file so that the resulting values look like the following: **Please note: the following below is an example not actual values you should use. Use one word to describe your project and follow the conventions below accordingly**
+* Change only the following lines in the ".env" file so that the resulting values look like the following: **Please note: the following below is an example not actual values you should use. Use one word to describe your project and follow the conventions below accordingly**
     * `COMPOSE_PROJECT_NAME=yourprojectnamehere_local`
     * `BASE_DOMAIN=yourprojectnamehere.localdomain`
     * `CONTAINER_SHORT_ID=ld` _leave default setting of `ld` as is. Do not change._
     * `COMPOSE_FILE=docker-compose.local.yml`
 
-* If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to make it so you can access port `3306` from the host computer. If you are already running MySQL on your personal computer, you'll have a port conflict and will need to either shutdown that service prior to running ISLE or change `3306:3306` to something like `9306:3306`. Please double-check.
+* Save and close the file.
 
-* Enter `Cntrl` and the letter `o` together to write the changes to the file.
+* Additionally, depending on your decision from "Step 0", you may need to make additional edits to `docker-compose.local.yml` and move files into place as directed from the (**Intermediate**) and (**Advanced**) sections.
 
-* Enter `Cntrl` and the letter `x` together to exit the file
+**Please note:** If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to make it so you can access port `3306` from the host computer. If you are already running MySQL on your personal computer, you'll have a port conflict and will need to either shutdown that service prior to running ISLE or change `3306:3306` to something like `9306:3306`. Please double-check.
 
 **Please note:** We highly recommend that you also review the contents of the `docker-compose.local.yml` file as the Apache service volume section uses bind mounts for the intended Drupal Code instead of using default Docker volumes. This allows users to perform Local Islandora Drupal site development with an IDE. This line is a suggested path and users are free to change values to the left of the `:` to match their Apache data folder of choice. However we recommend starting out with the default setting below.
 Default: `- ./data/apache/html:/var/www/html:cached`
-
-* Additionally, depending on your decision from "Step 0", you may need to make additional edits to `docker-compose.local.yml` and move files into place as directed from the (**Intermediate**) and (**Advanced**) sections.
 
 ---
 
 ## Step 5: Create New Users and Passwords by Editing "local.env" File
 
-You can reuse some of the older Production settings in the "local.env" if you like (e.g. the database name `DRUPAL_DB`, database user `DRUPAL_DB_USER` even the drupal database user password `DRUPAL_DB_PASS` if that makes it easier). It is important to avoid repeating passwords in the ISLE Staging and Production environments.
+You can reuse some of the older Production settings in the "local.env" if you like (e.g. the database name "DRUPAL_DB", database user "DRUPAL_DB_USER" even the drupal database user password "DRUPAL_DB_PASS" if that makes it easier). It is important to avoid repeating passwords in the ISLE Staging and Production environments.
 
 * Open the "local.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
@@ -295,7 +311,7 @@ You can reuse some of the older Production settings in the "local.env" if you li
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open the `config/apache/settings_php/settings.local.php` file in a text editor.
+* Open the "config/apache/settings_php/settings.local.php" file in a text editor.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
@@ -305,30 +321,31 @@ You can reuse some of the older Production settings in the "local.env" if you li
 ## Step 6: Create New Self-Signed Certs for Your Project
 
 * Open the appropriate file in a text editor:
-    * **For Mac/Ubuntu/CentOS/etc:** `./scripts/proxy/ssl-certs/local.sh`
-    * **For Microsoft Windows:** `./scripts/proxy/ssl-certs/local-windows-only.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** "./scripts/proxy/ssl-certs/local.sh"
+    * **For Microsoft Windows:** "./scripts/proxy/ssl-certs/local-windows-only.sh"
+
 * Follow the in-line instructions to add your project's name to the appropriate areas.
     * Once finished, save and close the file.
 
-* _Using the same open terminal:_, navigate to `/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
+* _Using the same open terminal:_, navigate to "/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/"
     * `cd ./scripts/proxy/ssl-certs/`
 
 * Change the permissions on the script to make it executable
     * **For Mac/Ubuntu/CentOS/etc:** `chmod +x local.sh`
     * **For Microsoft Windows:** `chmod +x local-windows-only.sh`
 
-* Run the following command to generate new self-signed SSL keys using your `yourprojectnamehere.localdomain` domain. This now secures the local site.
+* Run the following command to generate new self-signed SSL keys using your "yourprojectnamehere.localdomain" domain. This now secures the local site.
     * **For Mac/Ubuntu/CentOS/etc:** `./local.sh`
     * **For Microsoft Windows:** `./local-windows-only.sh`
     * The generated keys can now be found in:
         * `cd ../../../config/proxy/ssl-certs`
 
-* Add the SSL .pem and .key file names generated from running the above script to the `./config/proxy/traefik.local.toml` file.
+* Add the SSL .pem and .key file names generated from running the above script to the "./config/proxy/traefik.local.toml" file.
     * `cd ..`
     * Open `traefik.local.toml` in a text editor.
-    * Example:
-    * `certFile = "/certs/yourprojectnamehere.localdomain.pem"`
-    * `keyFile = "/certs/yourprojectnamehere.localdomain.key"`
+    * **Example:**
+        * `certFile = "/certs/yourprojectnamehere.localdomain.pem"`
+        * `keyFile = "/certs/yourprojectnamehere.localdomain.key"`
 
 ---
 
@@ -350,8 +367,8 @@ You can reuse some of the older Production settings in the "local.env" if you li
 * _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
-    * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
-      * **If any of these are not `UP`, then use [Non-Running Docker Containers](../install/install-troubleshooting.md#non-running-docker-containers) to solve before continuing below.**
+    * All containers prefixed with "isle-" are expected to have a "STATUS" of "Up" (for x time).
+      * **If any of these are not "UP", then use [Non-Running Docker Containers](../install/install-troubleshooting.md#non-running-docker-containers) to solve before continuing below.**
       <!---TODO: This could be confusing if (a) there are other, non-ISLE containers, or (b) the isle-varnish container is installed but intentionally not running, oe (c) older exited ISLE containers that maybe should be removed. --->
 
 ## Step 9: Import the Production MySQL Drupal Database
@@ -363,14 +380,14 @@ You can reuse some of the older Production settings in the "local.env" if you li
     * Port: `3306` _or a different port if you changed it_
     * Username: `root`
     * Password: `YOUR_MYSQL_ROOT_PASSWORD` in the "local.env")
-* Select the Drupal database `DRUPAL_DB` in the "local.env")
+* Select the Drupal database "DRUPAL_DB" in the "local.env")
 * Click File > Import (_or equivalent_)
-* Select your exported Production Islandora Drupal database file e.g. `prod_drupal_site_082019.sql.gz`
+* Select your exported Production Islandora Drupal database file (e.g. "prod_drupal_site_082019.sql.gz")
 * The import process will take 1 -3 minutes depending on the size.
 
 **Method B: Use the command line**
 
-* Copy the Production Islandora Drupal database file e.g. `prod_drupal_site_082019.sql.gz` to your ISLE MySQL container
+* Copy the Production Islandora Drupal database file (e.g. "prod_drupal_site_082019.sql.gz") to your ISLE MySQL container
     * Run `docker ps` to determine the mysql container name
     * `docker cp /pathto/prod_drupal_site_082019.sql.gz your-mysql-containername:/prod_drupal_site_082019.sql.gz`
     * **Example:**
@@ -415,7 +432,7 @@ Since you've imported an existing Drupal database, you must now reinstall the Is
     * **For Microsoft Windows:** `winpty docker exec -it your-apache-containername bash -c "cd /var/www/html && ./install_solution_packs.sh"`
 * The above process will take a few minutes depending on the speed of your local and Internet connection.
     * You should see a lot of green [ok] messages.
-    * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
+    * If the script appears to pause or prompt for "y/n", DO NOT enter any values; the script will automatically answer for you.
 
 | Microsoft Windows |
 | :-------------      |
@@ -425,7 +442,7 @@ Since you've imported an existing Drupal database, you must now reinstall the Is
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
+* **Proceed only after this message appears:** "Done. 'all' cache was cleared."
 
 ---
 
@@ -501,8 +518,8 @@ Once you are ready to deploy your finished Drupal site, you may progress to:
 ---
 
 ## Additional Resources
-* [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE endusers should use for the `.env`, `local.env`, etc.
-* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator tools.
+* [ISLE Installation: Environments](../install/install-environments.md) helps explain the ISLE workflow structure, the associated files, and what values ISLE endusers should use for the ".env", "local.env", etc.
+* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator testing.
 * [ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/install-local-new.md
+++ b/docs/install/install-local-new.md
@@ -1,14 +1,14 @@
 # Local ISLE Installation: New Site
 
-_Expectations:  It takes an average of **60-120 minutes** to read this documentation and complete this installation._
+_Expectations:  It takes an average of **1-2 hours** to read this documentation and complete this installation._
 
-This `Local` ISLE Installation creates an un-themed Drupal website and an empty Fedora repository similar to the `Demo` installation but one that you can use to develop and design your Drupal site and Fedora collections with the end goal of deploying to ISLE Staging and Production environments for public use.
+This Local ISLE Installation creates an un-themed Drupal website and an empty Fedora repository (similar to the Demo installation) but one that you can use to develop and design your Drupal site and Fedora collections with the end goal of deploying to ISLE Staging and Production environments for public use.
 
-You will now be able to change the ability to view locally in your browser from the Demo url `https://isle.localdomain` to a new domain of your choice for example `https://yourprojectnamehere.localdomain`.
+This Local ISLE Installation will allow you to locally view this site in your browser with the domain of your choice (**Example:** "https://yourprojectnamehere.localdomain"), instead of being constrained to the Demo URL ("https://isle.localdomain").
 
-While this installation gets you a brand new local development site, it is **not** intended as a migration process of a previously existing Islandora site. If you need to build a local environment to migrate a previously existing Islandora site, please use the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions instead.
+While this installation provides you a brand new local development site, it is **not** intended as a migration process of a previously existing Islandora site. If you need to build a local environment to migrate a previously existing Islandora site, please use the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md)  instead.
 
-This document also has directions on how you can check in newly created ISLE and Islandora code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE endusers should use for the `.env`, `local.env`, etc.
+This document also has directions on how you can save newly created ISLE and Islandora code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging to Production. The [ISLE Installation: Environments](../install/install-environments.md) helps explain the ISLE workflow structure, the associated files, and what values ISLE endusers should use for the ".env", "local.env", etc.
 
 Please post questions to the public [Islandora ISLE Google group](https://groups.google.com/forum/#!forum/islandora-isle), or subscribe to receive emails. The [Glossary](../appendices/glossary.md) defines terms used in this documentation.
 
@@ -16,9 +16,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * This Local ISLE installation is intended for a brand new ISLE site for further Drupal theme development, ingest testing, etc. on a personal computer.
 
-* You will be using ISLE version `1.2.0` or higher
+* You will be using ISLE version **1.2.0** or higher.
 
-* You are using Docker-compose `1.24.0` or higher
+* You are using Docker-compose **1.24.0** or higher.
 
 * You have git installed on your personal computer.
 
@@ -27,14 +27,16 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
     * **WARNING:** Only use **Private** git repositories given the sensitive nature of the configuration files. **DO NOT** share these git repositories publicly.
 
 * **For Microsoft Windows:**
-    * You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git Bash" as your command line interface; this behaves similarly to LINUX and UNIX environments. Git for Windows also installs `openssl.exe` which will be needed to generate self-signed SSL certs. (Note: Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.)
+    * You have installed [Git for Windows](../install/host-software-dependencies.md#windows) and will use its provided "Git Bash" as your command line interface; this behaves similarly to LINUX and UNIX environments. Git for Windows also installs "openssl.exe" which will be needed to generate self-signed SSL certs. (Note: Powershell is not recommended as it is unable to run UNIX commands or execute bash scripts without a moderate degree of customization.)
     * Set your text editor to use UNIX style line endings for files. (Text files created on DOS/Windows machines have different line endings than files created on Unix/Linux. DOS uses carriage return and line feed ("\r\n") as a line ending, which Unix uses just line feed ("\n").)
+    * In the "local.env" file, you must uncomment the line "# COMPOSE_CONVERT_WINDOWS_PATHS=1". (See Software Dependencies: [Edit "demo.env" or "local.env"](../install/host-software-dependencies.md#edit-demoenv-or-localenv))
 
 ---
 
 ## Index of Instructions
 
-* Step 1: Edit "/etc/hosts" File
+* Step 1: Choose a Project Name
+* Step 1.5: Edit "/etc/hosts" File
 * Step 2: Setup Git for the ISLE Project
 * Step 3: Edit the ".env" File to Point to the Local Environment
 * Step 4: Create New Users and Passwords by Editing "local.env" File
@@ -48,43 +50,54 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 ---
 
-## Step 1: Edit "/etc/hosts" File
+## Step 1: Choose a Project Name
 
-Enable the Local ISLE Installation to be viewed locally on personal computer browser as: e.g. `https://yourprojectnamehere.localdomain`.
+Please choose a project name (concatenated, with no spaces) that describes your institution or your collection platform. You will substitute in your preferred project name whenever the documentation refers to "yourprojectnamehere". (Be creative. Some real-life examples include: arminda, dhinitiative, digital, digitalcollections, digitallibrary, unbound, etc.)
+
+---
+
+## Step 1.5: Edit "/etc/hosts" File
+
+Enable the Local ISLE Installation to be viewed locally on a personal computer browser using "yourprojectnamehere" (e.g. "https://yourprojectnamehere.localdomain").
 
 * Please use these instructions to [Edit the "/etc/hosts" File](../install/install-demo-edit-hosts-file.md).
-
-* Replace `isle` or `yourprojectnamehere` with your domain or project name: e.g. `yourprojectnamehere.localdomain`
 
 ---
 
 ## Step 2: Setup Git for the ISLE Project
 
-**Please note:** The commands given below are for command line usage of git. GUI based clients such as the [SourceTree App](https://www.sourcetreeapp.com/) may be easier for endusers to use for the git process.
+**Please note:** The commands given below are for command line usage of git. (GUI based clients such as the [SourceTree App](https://www.sourcetreeapp.com/) may be easier for endusers to use for the git process.)
 
-Within your git repository provider / hoster (e.g [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com)), create two new empty git repositories:
+Each "suggested git repository name" (below) serves to clearly name and distinguish your ISLE code from your Islandora code. It's very important to understand that these are two separate code repositories, and not to confuse them.
 
-1. ISLE project config - e.g. `yourprojectnamehere-isle`
-    * This Git repository will hold your copy of the ISLE code along with your environment-specific customizations. Storing this in a code repository and following the workflow described here will save you a lot of time and confusion.
-2. Islandora Drupal site code - e.g. `yourprojectnamehere-islandora`
-    * This Git repository will hold your copy of the Islandora Drupal code along with your site specific customizations. Storing this in a code repository and following the workflow described here will save you a lot of time and confusion.
+Create the following two new, empty, private git repositories within your git repository hosting service (e.g [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com)):
 
-The git project name can be your institution name or the name of the collections you plan to deploy; your choice entirely. A very clear distinction between the ISLE and Islandora code should be made in the repository name. Do not confuse or label Islandora Drupal site code as ISLE and vice-versa.
+1. ISLE project configuration repository
+    * **Suggested git repository name:** `yourprojectnamehere-isle`
+    * This Git repository will hold your copy of the ISLE code along with your environment-specific customizations. Storing this in a private repository and following the workflow below will save you a lot of time and confusion.
+2. Islandora Drupal code repository
+    * **Suggested git repository name:** `yourprojectnamehere-islandora`
+    * This Git repository will hold your copy of the Islandora Drupal code along with your site specific customizations. Storing this in a private repository and following the workflow below will save you a lot of time and confusion.
 
-Clone this newly created ISLE project to your personal computer
+Clone this newly created ISLE project to your personal computer:
 
-  * Open a `terminal` (Windows: open `Git Bash`)
-  * Navigate to a directory that will house your new ISLE project directory using the `cd` command.
-  * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git`
+* Open a `terminal` (Windows: open `Git Bash`)
+* Navigate to a directory that will house your new ISLE project directory using the `cd` command.
+* **Example:** `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git`
 
-Navigate to this directory
+* Navigate to the directory that was just created by the clone operation:
 
-  * `cd /path/to/your/repository`
+    * `cd /path/to/your/repository`
 
-Add the ICG ISLE git repository as a git upstream. (_the code below is a real path and command_)
+* Add the ICG ISLE git repository as a git upstream:
 
-  * `git remote add icg-upstream https://github.com/Islandora-Collaboration-Group/ISLE.git`
-  * you can check by running this command: `git remote -v`
+    * `git remote add icg-upstream https://github.com/Islandora-Collaboration-Group/ISLE.git`
+
+* View your remotes:
+
+    * `git remote -v`
+
+* You should now see the following:
 
 ```bash  
 icg-upstream	https://github.com/Islandora-Collaboration-Group/ISLE.git (fetch)
@@ -93,44 +106,42 @@ origin	https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-i
 origin	https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git (push)
 ```
 
-Run a git fetch
+* Run a git fetch
 
-  * `git fetch icg-upstream`
+    * `git fetch icg-upstream`
 
-Pull down the ICG ISLE `master` branch into your local project's `master` branch
+* Pull down the ICG ISLE "master" branch into your local project's "master" branch
 
-  * `git pull icg-upstream master`
-  * if you `ls -lha` in this directory, you'll now have code.
+    * `git pull icg-upstream master`
 
-Push this code to your online git provider ISLE
+* View the ISLE code you now have in this directory:
 
-  * `git push -u origin master`
-  * This will take 2-5 mins depending on your internet speed.
+    * `ls -lha`
 
-Now you have the current ISLE project code checked into git as foundation to make changes on specific to your local and project needs. You'll use this git "icg-upstream" process in the future to pull updates and releases from the main ISLE project.
+* Push this code to your online git provider ISLE
+
+    * `git push -u origin master`
+    * This will take 2-5 minutes depending on your internet speed.
+
+Now you have the current ISLE project code checked into git as a foundation to make changes on specific to your local and project needs. You'll use this git "icg-upstream" process in the future to pull updates and releases from the main ISLE project.
 
 ---
 
 ## Step 3: Edit the ".env" File to Point to the Local Environment
 
-Open a `terminal` (Windows: open `Git Bash`)
+* Navigate to your ISLE project directory.
 
-* Navigate to your ISLE project directory. (You may already be in this directory if you are coming from the [Software Dependencies](../install/host-software-dependencies.md).)
+* Open the ".env" file in a text editor.
 
-* Open `.env` file by running: `nano .env`
-    * _For endusers familiar with editing files on the command line, vim, emacs or alternative tools can be used in lieu of nano_
-
-* Change only the following lines in the `.env` file so that the resulting values look like the following: **Please note: the following below is an example not actual values you should use. Use one word to describe your project and follow the conventions below accordingly**
+* Change only the following lines in the ".env" file so that the resulting values look like the following: **Please note: the following below is an example not actual values you should use. Use one word to describe your project and follow the conventions below accordingly**
     * `COMPOSE_PROJECT_NAME=yourprojectnamehere_local`
     * `BASE_DOMAIN=yourprojectnamehere.localdomain`
     * `CONTAINER_SHORT_ID=ld` _leave default setting of `ld` as is. Do not change._
     * `COMPOSE_FILE=docker-compose.local.yml`
 
-* If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to make it so you can access port `3306` from the host computer. If you are already running MySQL on your personal computer, you'll have a port conflict and will need to either shutdown that service prior to running ISLE or change `3306:3306` to something like `9306:3306`. Please double-check.
+* Save and close the file.
 
-* Enter `Cntrl` and the letter `o` together to write the changes to the file.
-
-* Enter `Cntrl` and the letter `x` together to exit the file
+**Please note:** If you want to use a MySQL client with a GUI to import the Production MySQL Drupal database you'll need to uncomment the `ports` section of the MySQL service within the `docker-compose.local.yml` to make it so you can access port `3306` from the host computer. If you are already running MySQL on your personal computer, you'll have a port conflict and will need to either shutdown that service prior to running ISLE or change `3306:3306` to something like `9306:3306`. Please double-check.
 
 ---
 
@@ -142,7 +153,7 @@ Open a `terminal` (Windows: open `Git Bash`)
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
-* Open the `config/apache/settings_php/settings.local.php` file in a text editor.
+* Open the "config/apache/settings_php/settings.local.php" file in a text editor.
     * Find the first comment that begins with: `# ISLE Configuration` and follow the commented instructions to edit the database, username and password.
     * Find the second comment that begins with: `# ISLE Configuration` and follow the instructions to edit the Drupal hash salt.
     * Once finished, save and close the file.
@@ -152,25 +163,31 @@ Open a `terminal` (Windows: open `Git Bash`)
 ## Step 5: Create New Self-Signed Certs for Your Project
 
 * Open the appropriate file in a text editor:
-    * **For Mac/Ubuntu/CentOS/etc:** `./scripts/proxy/ssl-certs/local.sh`
-    * **For Microsoft Windows:** `./scripts/proxy/ssl-certs/local-windows-only.sh`
+    * **For Mac/Ubuntu/CentOS/etc:** "./scripts/proxy/ssl-certs/local.sh"
+    * **For Microsoft Windows:** "./scripts/proxy/ssl-certs/local-windows-only.sh"
+
 * Follow the in-line instructions to add your project's name to the appropriate areas.
     * Once finished, save and close the file.
 
-* _Using the same open terminal:_, navigate to `/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
-    * `cd /pathto/yourprojectnamehere/scripts/proxy/ssl-certs/`
+* _Using the same open terminal:_, navigate to "/pathto/yourprojectnamehere/scripts/proxy/ssl-certs/"
+    * `cd ./scripts/proxy/ssl-certs/`
+
+* Change the permissions on the script to make it executable
     * **For Mac/Ubuntu/CentOS/etc:** `chmod +x local.sh`
     * **For Microsoft Windows:** `chmod +x local-windows-only.sh`
 
-* The following command will generate new self-signed SSL keys using your `yourprojectnamehere.localdomain` domain. This now secures the local site.
+* Run the following command to generate new self-signed SSL keys using your "yourprojectnamehere.localdomain" domain. This now secures the local site.
     * **For Mac/Ubuntu/CentOS/etc:** `./local.sh`
     * **For Microsoft Windows:** `./local-windows-only.sh`
-    * The generated keys can now be found in `./config/proxy/ssl-certs`
+    * The generated keys can now be found in:
+        * `cd ../../../config/proxy/ssl-certs`
 
 * Add the SSL .pem and .key file names generated from running the above script to the `./config/proxy/traefik.local.toml` file.
-    * Example:
-    * `certFile = "/certs/yourprojectnamehere.localdomain.pem"`
-    * `keyFile = "/certs/yourprojectnamehere.localdomain.key"`
+    * `cd ..`
+    * Open `traefik.local.toml` in a text editor.
+    * **Example:**
+        * `certFile = "/certs/yourprojectnamehere.localdomain.pem"`
+        * `keyFile = "/certs/yourprojectnamehere.localdomain.key"`
 
 ---
 
@@ -192,25 +209,26 @@ Open a `terminal` (Windows: open `Git Bash`)
 * _Using the same open terminal:_
     * View only the running containers: `docker ps`
     * View all containers (both those running and stopped): `docker ps -a`
-    * All containers prefixed with `isle-` are expected to have a `STATUS` of `Up` (for x time).
-      * **If any of these are not `UP`, then use [ISLE Installations: Troubleshooting](install-troubleshooting.md) to solve before continuing below.**
+    * All containers prefixed with "isle-" are expected to have a "STATUS" of "Up" (for x time).
+      * **If any of these are not "UP", then use [Non-Running Docker Containers](../install/install-troubleshooting.md#non-running-docker-containers) to solve before continuing below.**
       <!---TODO: This could be confusing if (a) there are other, non-ISLE containers, or (b) the isle-varnish container is installed but intentionally not running, oe (c) older exited ISLE containers that maybe should be removed. --->
 
 ---
 
 ## Step 8: Run Islandora Drupal Site Install Script
 
-We highly recommend that you first review the contents of the `docker-compose.local.yml` file as the ISLE Apache service uses bind mounts for the intended Drupal Code instead of using default Docker volumes. This allows users to perform Local Islandora Drupal site development with an IDE. This line is a suggested path and users are free to change values to the left of the `:` to match their Apache data folder of choice. However we recommend starting out with the default setting below.
-Default: `- ./data/apache/html:/var/www/html:cached`
+We highly recommend that you first review the contents of the "docker-compose.local.yml" file as the ISLE Apache service uses bind mounts for the intended Drupal Code instead of using default Docker volumes. This allows users to perform Local Islandora Drupal site development with an IDE. This line is a suggested path and users are free to change values to the left of the `:` to match their Apache data folder of choice. We recommend starting out with the default setting: "- ./data/apache/html:/var/www/html:cached"
 
-Initially when starting up, end-users will need to run the install script and then ultimately check the resulting Drupal code into a git repository. If you are familiar with that process then Step 9.
+Run the install site script on the Apache container by copying and pasting the appropriate command:
 
-* Run the install site script on the Apache container by copying and pasting the appropriate command:
-    * **For Mac/Ubuntu/CentOS/etc:** `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
-    * **For Microsoft Windows:** `winpty docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
-* The above process may take 10-20 minutes (_depending on system and internet speeds_)
-    * You should see a lot of green [ok] messages.
-    * If the script appears to pause or prompt for `y/n`, DO NOT enter any values; the script will automatically answer for you.
+* **For Mac/Ubuntu/CentOS/etc:** `docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
+* **For Microsoft Windows:** `winpty docker exec -it isle-apache-ld bash -c "cd /utility-scripts/isle_drupal_build_tools && ./isle_islandora_installer.sh`
+
+The above process may take 10-20 minutes (_depending on system and internet speeds_)
+
+* You should see a lot of green [ok] messages.
+* If the script appears to pause or prompt for "y/n", DO NOT enter any values; the script will automatically answer for you.
+
 
 | Microsoft Windows |
 | :-------------      |
@@ -220,7 +238,7 @@ Initially when starting up, end-users will need to run the install script and th
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
+* **Proceed only after this message appears:** "Done. 'all' cache was cleared."
 
 ---
 
@@ -254,7 +272,7 @@ git clone https://github.com/Islandora-Collaboration-Group/islandora-sample-obje
 
 * _Using the same open terminal:_
 
-* Navigate to the `data` directory within your local ISLE project
+* Navigate to the "data" directory within your local ISLE project
     * `cd data/apache/html`
 
 * Create a local git repository
@@ -267,10 +285,10 @@ git clone https://github.com/Islandora-Collaboration-Group/islandora-sample-obje
     * Between the `""` add a message like "Setting up Drupal site" that reflects the changes you are making in the Drupal code.
     * `git commit -m "Setting up Drupal site"`
 
-* Add the git `remote` (this will be remote / cloud based git repository that you'll push changes to). This can be Bitbucket, Github or Gitlab.
+* Add the git "remote" (this represents your git repository hosting service that you'll push changes to). This can be Bitbucket, Github or Gitlab.
     * **Example:** `git remote add origin https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git`
 
-* Push the changes to the remote git repository on the `master` branch
+* Push the changes to the remote git repository on the "master" branch
     * `git push -u origin master`
 
 * Then continue to develop work within this follow your institutional best practice to application git repository.
@@ -286,8 +304,8 @@ Once you are ready to deploy your finished Drupal site, you may progress to:
 ---
 
 ## Additional Resources
-* [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE endusers should use for the `.env`, `local.env`, etc.
-* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator tools.
+* [ISLE Installation: Environments](../install/install-environments.md) helps explain the ISLE workflow structure, the associated files, and what values ISLE endusers should use for the ".env", "local.env", etc.
+* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator testing.
 * [ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/install-production-migrate.md
+++ b/docs/install/install-production-migrate.md
@@ -2,25 +2,25 @@
 
 _Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
-This `Production` ISLE Installation will be similar to the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions you just followed but in addition to using a copy of your currently running Production themed Drupal website, a copy of the Production Fedora repository will also be needed for you to continue migrating to ISLE with the end goal of first deploying to an ISLE Production environment and then cut over from the existing non-ISLE Production and Production servers to their new ISLE counterparts.
+This Production ISLE Installation will be similar to the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions you just followed but in addition to using a copy of your currently running Production themed Drupal website, a copy of the Production Fedora repository will also be needed for you to continue migrating to ISLE with the end goal of first deploying to an ISLE Production environment and then cut over from the existing non-ISLE Production and Production servers to their new ISLE counterparts.
 
 Islandora Drupal site code here should be finished and ready for public consumption. Fedora data will be a mirror of your currently running non-ISLE Production Fedora repository. It is recommended that this remote site not be publicly accessible until you are ready to cutover and give public access.
 
-This installation builds a `Production` environment for the express purpose of migrating a previously existing Islandora site onto the ISLE platform. If you need to build a brand new `Production` site for development and are not migrating an existing Islandora site, then please **stop** and use the [Production ISLE Installation: New Site](../install/install-production-new.md) instructions instead.
+This installation builds a Production environment for the express purpose of migrating a previously existing Islandora site onto the ISLE platform. If you need to build a brand new Production site for development and are not migrating an existing Islandora site, then please **stop** and use the [Production ISLE Installation: New Site](../install/install-production-new.md)  instead.
 
-As this `Production` domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your `Production` Host Server IP address in your institution's DNS records.
+As this Production domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your Production Host Server IP address in your institution's DNS records.
 
 Example:`https://yourprojectnamehere.institution.edu`
 
 Once this has been completed, if you do not want to use Let's Encrypt, you can also request commercial SSL certificates from your IT department for this domain as well. Please note the DNS records will need to exist prior to the creation of any SSL certificate (Commercial or Let's Encrypt.)
 
-* If you already have pre-existing `Production` commercial SSL certificates, they can certainly be reused and copied into the ISLE project as directed.
+* If you already have pre-existing Production commercial SSL certificates, they can certainly be reused and copied into the ISLE project as directed.
 
 Unlike the Local and Demo setups, you will not have to edit `/etc/localhosts` to view your domain given that DNS is now involved. Your new domain will no longer use the `.localdomain` but instead something like `https://yourprojectnamehere.institution.edu`
 
-This document also has directions on how you can check in newly updated ISLE code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Production and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `production.env`, etc.
+This document also has directions on how you can save newly updated ISLE code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Production and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `production.env`, etc.
 
-This document **does not** have directions on how you can check in previously existing Islandora Drupal code into a git repository and assumes this step has already happened. The directions below will explain how to clone Islandora Drupal code from a previously existing Islandora Drupal git repository that should already be accessible to you.
+This document **does not** have directions on how you can save previously existing Islandora Drupal code into a git repository and assumes this step has already happened. The directions below will explain how to clone Islandora Drupal code from a previously existing Islandora Drupal git repository that should already be accessible to you.
 
 Please post questions to the public [Islandora ISLE Google group](https://groups.google.com/forum/#!forum/islandora-isle), or subscribe to receive emails. The [Glossary](../appendices/glossary.md) defines terms used in this documentation.
 
@@ -29,9 +29,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 * This Production ISLE installation is intended for an existing Production Islandora Drupal site to be imported along with a copy of the current Production Fedora Repository for further ISLE migration testing, Drupal theme development, ingest testing, etc. on a remote ISLE host server.
     * Some materials are to be "migrated" from the work you performed on your personal computer from the prior steps and processes in [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions.
 
-* You will be using ISLE version `1.2.0` or higher
+* You will be using ISLE version **1.2.0** or higher.
 
-* You are using Docker-compose `1.24.0` or higher
+* You are using Docker-compose **1.24.0** or higher.
 
 * You have git installed on your personal computer as well as the remote ISLE host server.
 
@@ -41,9 +41,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
           * [Hardware Requirements](host-hardware-requirements.md)
           * [Software Dependencies](host-software-dependencies.md)
       * This server should be running at the time of deploy.
-      * **Critical** - This `Production` server has the same amount of disk space as your current Production Fedora server does in order to store a copy of the Fedora repository. Please ensure that these sizes match. Please also plan on adding additional capacity as needed for any potential ingest testing, etc.
+      * **Critical** - This Production server has the same amount of disk space as your current Production Fedora server does in order to store a copy of the Fedora repository. Please ensure that these sizes match. Please also plan on adding additional capacity as needed for any potential ingest testing, etc.
 
-* You have a previously existing private Islandora Drupal git repository
+* You have a previously existing private Islandora Drupal git repository.
 
 * You have access to a private git repository in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc.
     * If you do not, please contact your IT department for git resources, or else create an account with one of the above providers.
@@ -59,9 +59,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
         * Remove the temporary DNS A record for `yourprojectnamehere-newprod.institution.edu`
         * If using commercial SSLs, you'll also need to copy them over to the `./config/proxy/ssl-certs` directory and adjust the `traefik.production.toml` file accordingly with the new file names.
 
-* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested `Production` values.
+* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested Production values.
 
-* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote `Production` server.
+* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote Production server.
 
 * You have access to your Production Islandora Drupal, Solr and Fedora data and copy from your servers to the new ISLE Production server.
 
@@ -71,9 +71,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 ## Index of Instructions
 
-This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the `Production` ISLE Host server with additional followup work to be performed on the remote `Production` ISLE Host server.
+This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the Production ISLE Host server with additional followup work to be performed on the remote Production ISLE Host server.
 
-The instructions that follow below will have either a `On Local` or a `On Remote Production` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Production` and for future ISLE updates and upgrades.
+The instructions that follow below will have either a `On Local` or a `On Remote Production` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on Production and for future ISLE updates and upgrades.
 
 **Steps 1-6: On Local - Configure the ISLE Production Environment Profile for Deploy to Remote**
 
@@ -112,7 +112,7 @@ You are repeating this step given that data may have changed on the Production s
 
 * Drupal website databases can have a multitude of names and conventions. Confer with the appropriate IT departments for your institution's database naming conventions.
 
-* Recommended that the production databases be exported using the `.sql` /or `.gz` file formats e.g. `prod_drupal_site_082019.sql.gz` for better compression and minimal storage footprint.
+* Recommended that the production databases be exported using the `.sql` /or `.gz` file formats (e.g. "prod_drupal_site_082019.sql.gz") for better compression and minimal storage footprint.
 
 * If the end user is running multi-sites, there will be additional databases to export.
 
@@ -123,8 +123,8 @@ You are repeating this step given that data may have changed on the Production s
 #### Export the Production MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current Production Islandora Drupal site in use and copy it to your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your Production site. If you are not comfortable or familiar with performing these actions, we recommend that you instead work with your available IT resources to do so.
-    * You can use a MySQL GUI client for this process or if you have command line access to the MySQL database server
-    `mysqldump -u username -p database_name > prod_drupal_site_082019.sql`
+    * To complete this process, you may use a MySQL GUI client or, if you have command line access to the MySQL database server, you may run the following command, substituting your actual user and database names:
+    * **Example:** `mysqldump -u username -p database_name > prod_drupal_site_082019.sql`
     * Copy this file down to your personal computer.
 
 ---
@@ -134,7 +134,7 @@ You are repeating this step given that data may have changed on the Production s
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
 * Once finished, open a `terminal` (Windows: open `Git Bash`)
-    * Navigate to your local ISLE directory
+    * Navigate to your Local ISLE repository
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
@@ -144,7 +144,7 @@ You are repeating this step given that data may have changed on the Production s
 * Open the "production.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
-        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Production` environment but we strongly recommend not reusing all passwords for environments (e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment).
+        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this Production environment but we strongly recommend not reusing all passwords for environments (e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment).
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
@@ -157,7 +157,7 @@ You are repeating this step given that data may have changed on the Production s
 
 ## Step 4: On Local - Review and Edit "docker-compose.production.yml"
 
-* Review the disks and volumes on your remote `Production` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.production.yml` file.
+* Review the disks and volumes on your remote Production ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.production.yml` file.
 
 * Please read through the `docker-compose.production.yml` file as there are bind mount points that need to be configured on the host machine, to ensure data persistence. There are suggested bind mounts that the end-user can change to fit their needs or they can setup additional volumes or disks to match the suggestions.
     * In the `fedora` services section
@@ -195,7 +195,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 * _(Optional)_ - This line is already uncommented by default in ISLE but we're calling it out here that you can changes to the suggested levels or values within the `./config/mysql/ISLE.cnf` file if needed. When setting up for the first time, it is best practice to leave these settings in place. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
-* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a `Production` ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
+* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a Production ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
 * _(Optional)_ - You can opt to uncomment the TICK stack settings for monitoring but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
   * All TICK related code can be found at the end of all ISLE services within the `docker-compose.production.yml` file.
@@ -209,7 +209,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
       tag: "{{.Name}}"
 ```
 
-  * Uncomment the lines found in the new TICK stack services section of the `docker-compose.production.yml` file for hosting of that monitoring service on the `Production` ISLE Host server.
+  * Uncomment the lines found in the new TICK stack services section of the `docker-compose.production.yml` file for hosting of that monitoring service on the Production ISLE Host server.
       * There are additional configurations to be made to files contained within `./config/tick` but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
   * Uncomment the TICK stack data volumes as well at the bottom of the file.
 
@@ -250,7 +250,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ## Step 6: On Local - Commit ISLE Code to Git Repository
 
-* Once you have made all of the appropriate changes to your `Production` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
+* Once you have made all of the appropriate changes to your Production profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
     * `git commit -m "Changes for Production"`
     * `git push origin master`
@@ -267,9 +267,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 Since the `/opt` directory might not let you do this at first, we suggest the following workaround which you'll only need to do once. Future ISLE updates will not require this step.
 
-* Shell into your `Production` ISLE host server as the `Islandora` user.
+* Shell into your Production ISLE host server as the `Islandora` user.
 
-* Clone your ISLE project repository with the newly committed changes for `Production` to the `Islandora` user home directory.
+* Clone your ISLE project repository with the newly committed changes for Production to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
     * This may take a few minutes (2-4) depending on your server's Internet connection.
 
@@ -306,17 +306,17 @@ Please clone from your existing Production Islandora git repository.
 * It is recommended that you schedule a content freeze for all Production Fedora ingests and additions to your Production website. This will allow you to get up to date data from Production to Production.
 
 * As you may have made some critical decisions potentially from "Step 0: Copy Production Data to Your Local" of the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions, you need to re-follow the steps to get your:
-    * `Production` Drupal site `files` directory
+    * Production Drupal site `files` directory
     * `Solr schema & Islandora transforms`
         * If you picked **Easy** option:
             * then you don't need to do anything here for the `Solr schema & Islandora transforms`
         * If you picked the **Intermediate** or **Advanced** options:
             * You'll need to copy in the customizations and files you created during the `local` environment into the `docker-compose.production.yml`. Ensure that one set of transforms and schema are used across all environments.
-    * `Production` Fedora `datastreamStore` directory
+    * Production Fedora `datastreamStore` directory
         * You'll need to adjust the paths below in case your setup differs on either the non-ISLE Production server or the ISLE Production server.
         * Copy your `/usr/local/fedora/data/datastreamStore` data to the suggested path of `/mnt/data/fedora/datastreamStore`
             * You may need to change the permissions to `root:root` on the Production `/mnt/data/fedora/datastreamStore` directory above after copying so the Fedora container can access properly. Do not do this on your existing Production system please.
-    * `Production` Fedora `objectStore`. 
+    * Production Fedora `objectStore`. 
         * Copy your `/usr/local/fedora/data/objectStore` data to the suggested path of `/opt/data/fedora/objectStore`
             * You may need to change the permissions to `root:root` on the Production `/opt/data/fedora/objectStore` above after copying so the Fedora container can access properly. Do not do this on your existing Production system please.
 
@@ -389,7 +389,7 @@ fatal: empty ident name (for <islandora@yourprojectnamehere.institution.edu>) no
 ```
 
 * Configure your server git client but don't use the `--global` setting as that could interfere with other git repositories e.g. your Islandora Drupal code.
-    * Example: Within `/opt/yourprojectnamehere`
+    * **Example:** Within `/opt/yourprojectnamehere`
     * `git config user.email "jane@institution.edu"`
     * `git config user.name "Jane Doe"`
 
@@ -448,11 +448,11 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Production server.
 
-* Import the exported `Local` MySQL database for use in the current `Production` Drupal site. Refer to your `production.env` for the usernames and passwords used below.
+* Import the exported Local MySQL database for use in the current Production Drupal site. Refer to your `production.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
     * _Using the same open terminal:_  
-    * Shell into your currently running "Production" MySQL container
+    * Shell into your currently running Production MySQL container
         * `docker exec -it your-mysql-containername bash`
     * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "production.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
@@ -476,7 +476,7 @@ This step will show you how to run the "migration_site_vsets.sh" script on the A
 * Run the script
     * `docker exec -it your-apache-containername bash -c "cd /var/www/html && ./migration_site_vsets.sh"`
 
-This step will show you how to shell into your currently running "Production" Apache container, and run the "fix-permissions.sh" script to fix the Drupal site permissions.
+This step will show you how to shell into your currently running Production Apache container, and run the "fix-permissions.sh" script to fix the Drupal site permissions.
 
 * `docker exec -it your-apache-containername bash`
 * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
@@ -515,7 +515,7 @@ Since this command can take minutes or hours depending on the size of your repos
 
 **Please note:** The method described below is a longer way of doing this process to onboard users.
 
-* Shell into your currently running "Production" Fedora container
+* Shell into your currently running Production Fedora container
 * Run `docker ps` to determine the Fedora container name
     * `docker exec -it your-fedora-containername bash`
 
@@ -565,7 +565,7 @@ Find logs at /usr/local/tomcat/logs/fgs-update-foxml.out and /usr/local/tomcat/l
 You can watch log file 'tail -f /usr/local/tomcat/logs/fedoragsearch.daily.log' as the process runs.
 ```
 
-**Please note:** Within this output, options to tail logs and watch progress are offered. Depending on the size of your collection this process may take hours, however it is okay to exit out of the container and even log off the remote `Production` server. You can check back frequently by running `tail -f /usr/local/tomcat/logs/fgs-update-foxml.out` on the Fedora container. If you visit your Drupal site and run a Solr search, you should start to see objects and facets start to work. The number of objects will increase over time.
+**Please note:** Within this output, options to tail logs and watch progress are offered. Depending on the size of your collection this process may take hours, however it is okay to exit out of the container and even log off the remote Production server. You can check back frequently by running `tail -f /usr/local/tomcat/logs/fgs-update-foxml.out` on the Fedora container. If you visit your Drupal site and run a Solr search, you should start to see objects and facets start to work. The number of objects will increase over time.
 
 * After a good period of time, again depending on the size of your Fedora collection, when the Solr re-index process finishes, output like the example below will appear in the `/usr/local/tomcat/logs/fgs-update-foxml.out` log. This indicates that the Solr reindex process was completed. The number of objects rebuilt will vary. You can hit the CNTRL and C keys to exit out of the tail process, if need be.
 
@@ -591,10 +591,10 @@ Args
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
 * Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "production.env".
-    * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
+    * **Please note:** You are free to use previously Drupal admin or user accounts created during the Local site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.
-    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous `Local` installation.
+    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous Local installation.
 
 ---
 
@@ -614,8 +614,8 @@ Once you are ready to deploy your finished Drupal site, you may progress to laun
 ---
 
 ## Additional Resources
-* [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `local.env`, etc.
-* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator tools.
+* [ISLE Installation: Environments](../install/install-environments.md) help with explaining the ISLE structure, the associated files, and what values ISLE end-users should use for the ".env", "local.env", etc.
+* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator testing.
 * [ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/install-production-new.md
+++ b/docs/install/install-production-new.md
@@ -2,11 +2,11 @@
 
 _Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
-This `Production` ISLE Installation will use the themed Drupal website created during the [Local ISLE Installation: New Site](../install/install-local-new.md) process and will create an empty Fedora repository for remote (non-local / cloud) hosting of a `Production` site. Islandora Drupal site code here should be considered finished and ready for public access. The previously used `Production` system might have Fedora data & collections that should then be synced to this `Production` site or endusers can choose to only ingest on `Production`. It is recommended that this remote site not be publicly accessible until ready to launch.
+This Production ISLE Installation will use the themed Drupal website created during the [Local ISLE Installation: New Site](../install/install-local-new.md) process and will create an empty Fedora repository for remote (non-local or cloud) hosting of a Production site. Islandora Drupal site code here should be considered finished and ready for public access. The previously used Production system might have Fedora data & collections that should then be synced to this Production site or endusers can choose to only ingest on Production. It is recommended that this remote site not be publicly accessible until ready to launch.
 
-While this installation will get you a brand new `Production` site, it is **not** intended as a migration process of a previously existing Islandora site. If you need to build a `Production` environment to migrate a previously existing Islandora site, please use the [Production ISLE Installation: Migrate Existing Islandora Site](../install/install-production-migrate.md) instructions instead.
+While this installation will get you a brand new Production site, it is **not** intended as a migration process of a previously existing Islandora site. If you need to build a Production environment to migrate a previously existing Islandora site, please use the [Production ISLE Installation: Migrate Existing Islandora Site](../install/install-production-migrate.md)  instead.
 
-As this `Production` domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your `Production` Host Server IP address in your institution's DNS records. 
+As this Production domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your Production Host Server IP address in your institution's DNS records. 
 
 Example:`https://yourprojectnamehere.institution.edu`
 
@@ -14,7 +14,7 @@ Once this has been completed, if you do not want to use Let's Encrypt, you can a
 
 Unlike the Local and Demo setups, you will not have to edit `/etc/localhosts` to view your domain given that DNS is now involved. Your new domain will no longer use the `.localdomain` but instead something like `https://yourprojectnamehere.institution.edu`
 
-This document also has directions on how you can check in newly created ISLE and Islandora code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Production and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `production.env`, etc.
+This document also has directions on how you can save newly created ISLE and Islandora code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Production and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `production.env`, etc.
 
 Please post questions to the public [Islandora ISLE Google group](https://groups.google.com/forum/#!forum/islandora-isle), or subscribe to receive emails. The [Glossary](../appendices/glossary.md) defines terms used in this documentation.
 
@@ -23,9 +23,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 * This Production ISLE installation is intended for a brand new ISLE site for ingest and public use on a remote ISLE host server.
     * All materials are to be "migrated" from the work you performed on your personal computer from the prior steps and processes in [Local ISLE Installation: New Site](../install/install-local-new.md) instructions.
 
-* You will be using ISLE version `1.2.0` or higher
+* You will be using ISLE version **1.2.0** or higher.
 
-* You are using Docker-compose `1.24.0` or higher
+* You are using Docker-compose **1.24.0** or higher.
 
 * You have git installed on your personal computer as well as the remote ISLE host server.
 
@@ -44,17 +44,17 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have already have the appropriate A record entered into your institutions DNS system and can resolve the Production domain (https://yourprojectnamehere.institution.edu) using a tool like https://www.whatsmydns.net/
 
-* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested `Production` values.
+* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested Production values.
 
-* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote `Production` server.
+* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote Production server.
 
 ---
 
 ## Index of Instructions
 
-This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the `Production` ISLE Host server with additional followup work to be performed on the remote `Production` ISLE Host server.
+This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the Production ISLE Host server with additional followup work to be performed on the remote Production ISLE Host server.
 
-The instructions that follow below will have either a `On Local` or a `On Remote Production` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Production` and for future ISLE updates and upgrades.
+The instructions that follow below will have either a `On Local` or a `On Remote Production` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on Production and for future ISLE updates and upgrades.
 
 **Steps 1-6: On Local - Configure the ISLE Production Environment Profile for Deploy to Remote**
 
@@ -97,7 +97,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 ### Export the Local MySQL Islandora Drupal Database
 
-* Export the MySQL database for the current `Local` Drupal site in use and copy it on your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your newly created and themed new Islandora site. Refer to your `local.env` for the usernames and passwords used below.
+* Export the MySQL database for the current Local Drupal site in use and copy it on your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your newly created and themed new Islandora site. Refer to your `local.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Shell into your currently running Local MySQL container
         * `docker exec -it your-mysql-containername bash`
@@ -115,7 +115,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
 * Once finished, open a `terminal` (Windows: open `Git Bash`)
-    * Navigate to your local ISLE directory
+    * Navigate to your Local ISLE repository
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
@@ -125,7 +125,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 * Open the "production.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
-        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Production` environment but we strongly recommend not reusing all passwords for environments (e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment).
+        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this Production environment but we strongly recommend not reusing all passwords for environments (e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment).
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
@@ -138,7 +138,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 ## Step 4: On Local - Review and Edit "docker-compose.production.yml"
 
-* Review the disks and volumes on your remote `Production` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.production.yml` file.
+* Review the disks and volumes on your remote Production ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.production.yml` file.
 
 * Please read through the `docker-compose.production.yml` file as there are bind mount points that need to be configured on the host machine, to ensure data persistence. There are suggested bind mounts that the end-user can change to fit their needs or they can setup additional volumes or disks to match the suggestions.
     * In the `fedora` service section
@@ -170,7 +170,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 * _(Optional)_ - This line is already uncommented by default in ISLE but we're calling it out here that you can changes to the suggested levels or values within the `./config/mysql/ISLE.cnf` file if needed. When setting up for the first time, it is best practice to leave these settings in place. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
-* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a `Production` ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
+* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a Production ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
 * _(Optional)_ - You can opt to uncomment the TICK stack settings for monitoring but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
     * All TICK related code can be found at the end of all ISLE services within the `docker-compose.production.yml` file.
@@ -184,7 +184,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
       tag: "{{.Name}}"
 ```
 
-    * Uncomment the lines found in the new TICK stack services section of the `docker-compose.production.yml` file for hosting of that monitoring service on the `Production` ISLE Host server. This will allow the TICK - Telegraf agent to report properly to either the TICK stack on your Staging server or a remote TICK server.
+    * Uncomment the lines found in the new TICK stack services section of the `docker-compose.production.yml` file for hosting of that monitoring service on the Production ISLE Host server. This will allow the TICK - Telegraf agent to report properly to either the TICK stack on your Staging server or a remote TICK server.
     * There are additional configurations to be made to files contained within `./config/tick` but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
 
 ---
@@ -224,7 +224,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ## Step 6: On Local - Commit ISLE Code to Git Repository
 
-* Once you have made all of the appropriate changes to your `Production` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
+* Once you have made all of the appropriate changes to your Production profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
     * `git commit -m "Changes for Production"`
     * `git push origin master`
@@ -241,9 +241,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 Since the `/opt` directory might not let you do this at first, we suggest the following workaround which you'll only need to do once. Future ISLE updates will not require this step.
 
-* Shell into your `Production` ISLE host server as the `Islandora` user.
+* Shell into your Production ISLE host server as the `Islandora` user.
 
-* Clone your ISLE project repository with the newly committed changes for `Production` to the `Islandora` user home directory.
+* Clone your ISLE project repository with the newly committed changes for Production to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
     * This may take a few minutes (2-4) depending on your server's Internet connection.
 
@@ -351,7 +351,7 @@ fatal: empty ident name (for <islandora@yourprojectnamehere.institution.edu>) no
 ```
 
 * Configure your server git client but don't use the `--global` setting as that could interfere with other git repositories e.g. your Islandora Drupal code.
-    * Example: Within `/opt/yourprojectnamehere`
+    * **Example:** Within `/opt/yourprojectnamehere`
     * `git config user.email "jane@institution.edu"`
     * `git config user.name "Jane Doe"`
 
@@ -410,10 +410,10 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Production server.
 
-* Import the exported `Local` MySQL database for use in the current `Production` Drupal site. Refer to your `production.env` for the usernames and passwords used below.
+* Import the exported Local MySQL database for use in the current Production Drupal site. Refer to your `production.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
-    * Shell into your currently running "Production" MySQL container
+    * Shell into your currently running Production MySQL container
         * `docker exec -it your-mysql-containername bash`
     * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "production.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
@@ -427,7 +427,7 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 
 * You'll need to fix the Drupal site permissions by running the `/fix-permissions.sh` script from the Apache container
     * Run `docker ps` to determine the Apache container name
-    * Shell into your currently running "Production" Apache container
+    * Shell into your currently running Production Apache container
         * `docker exec -it your-apache-containername bash`
         * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
         * This process will take 2-5 minutes
@@ -442,7 +442,7 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
+* **Proceed only after this message appears:** "Done. 'all' cache was cleared."
 
 ---
 
@@ -452,10 +452,10 @@ git commit -m "Added the edited .env configuration file for Production. DO NOT P
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
 * Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "production.env".
-    * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
+    * **Please note:** You are free to use previously Drupal admin or user accounts created during the Local site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.
-    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous `Local` installation.
+    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous Local installation.
 
 ---
 
@@ -466,8 +466,8 @@ Once you are ready to deploy your finished Drupal site, you may progress to laun
 ---
 
 ## Additional Resources
-* [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `local.env`, etc.
-* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator tools.
+* [ISLE Installation: Environments](../install/install-environments.md) help with explaining the ISLE structure, the associated files, and what values ISLE end-users should use for the ".env", "local.env", etc.
+* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator testing.
 * [ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/install-staging-migrate.md
+++ b/docs/install/install-staging-migrate.md
@@ -2,31 +2,31 @@
 
 _Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
-This `Staging` ISLE Installation will be similar to the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions you just followed but in addition to using a copy of your currently running Production themed Drupal website, a copy of the Production Fedora repository will also be needed for you to continue migrating to ISLE with the end goal of first deploying to an ISLE Production environment and then cut over from the existing non-ISLE Production and Staging servers to their new ISLE counterparts.
+This Staging ISLE Installation will be similar to the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions you just followed but in addition to using a copy of your currently running Production themed Drupal website, a copy of the Production Fedora repository will also be needed for you to continue migrating to ISLE with the end goal of first deploying to an ISLE Production environment and then cut over from the existing non-ISLE Production and Staging servers to their new ISLE counterparts.
 
-Islandora Drupal site code here should be considered almost finished but hosted here for last touches and team review privately prior to pushing to public `Production`. Fedora data will be a mirror of your currently running Production Fedora repository. It is recommended that this remote site not be publicly accessible.
+Islandora Drupal site code here should be considered almost finished but hosted here for last touches and team review privately prior to pushing to public Production. Fedora data will be a mirror of your currently running Production Fedora repository. It is recommended that this remote site not be publicly accessible.
 
-This installation builds a `Staging` environment for the express purpose of migrating a previously existing Islandora site onto the ISLE platform. If you need to build a brand new `Staging` site for development and are not migrating an existing Islandora site, then please **stop** and use the [Local ISLE Installation: New Site](../install/install-local-new.md) instructions first and then the [Staging ISLE Installation: New Site](../install/install-staging-new.md) instead.
+This installation builds a Staging environment for the express purpose of migrating a previously existing Islandora site onto the ISLE platform. If you need to build a brand new Staging site for development and are not migrating an existing Islandora site, then please **stop** and use the [Local ISLE Installation: New Site](../install/install-local-new.md) instructions first and then the [Staging ISLE Installation: New Site](../install/install-staging-new.md) instead.
 
-As this `Staging` domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), we recommend the following:
+As this Staging domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), we recommend the following:
 
-* If you do not have a `Staging` server:
-    * Work with your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your new `Staging` Host Server IP address in your institution's DNS records. We recommend that this sub-domain use `-staging` to differentiate it from the Production site
+* If you do not have a Staging server:
+    * Work with your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your new Staging Host Server IP address in your institution's DNS records. We recommend that this sub-domain use `-staging` to differentiate it from the Production site
     * Example:`https://yourprojectnamehere-staging.institution.edu`
 
-* If you have a current non-ISLE `Staging` server(s):
-    * You shutdown any current non-ISLE `Staging` servers and only use the ISLE server from now on.
-    * Work with your IT department or appropriate resource for the existing "A record" for the current non-ISLE `Staging` domain to now "point" to your new `Staging` Host Server IP address in your institution's DNS records. **This is critical to be performed PRIOR to any further work below.**
+* If you have a current non-ISLE Staging server(s):
+    * You shutdown any current non-ISLE Staging servers and only use the ISLE server from now on.
+    * Work with your IT department or appropriate resource for the existing "A record" for the current non-ISLE Staging domain to now "point" to your new Staging Host Server IP address in your institution's DNS records. **This is critical to be performed PRIOR to any further work below.**
 
 Once this has been completed, if you do not want to use Let's Encrypt, you can also request commercial SSL certificates from your IT department for this domain as well. Please note the DNS records will need to exist prior to the creation of any SSL certificate (Commercial or Let's Encrypt.)
 
-* If you already have pre-existing `Staging` commercial SSL certificates, they can certainly be reused and copied into the ISLE project as directed.
+* If you already have pre-existing Staging commercial SSL certificates, they can certainly be reused and copied into the ISLE project as directed.
 
 Unlike the Local and Demo setups, you will not have to edit `/etc/localhosts` to view your domain given that DNS is now involved. Your new domain will no longer use the `.localdomain` but instead something like `https://yourprojectnamehere-staging.institution.edu`
 
-This document also has directions on how you can check in newly updated ISLE code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `staging.env`, etc.
+This document also has directions on how you can save newly updated ISLE code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `staging.env`, etc.
 
-This document **does not** have directions on how you can check in previously existing Islandora Drupal code into a git repository and assumes this step has already happened. The directions below will explain how to clone Islandora Drupal code from a previously existing Islandora Drupal git repository that should already be accessible to you.
+This document **does not** have directions on how you can save previously existing Islandora Drupal code into a git repository and assumes this step has already happened. The directions below will explain how to clone Islandora Drupal code from a previously existing Islandora Drupal git repository that should already be accessible to you.
 
 Please post questions to the public [Islandora ISLE Google group](https://groups.google.com/forum/#!forum/islandora-isle), or subscribe to receive emails. The [Glossary](../appendices/glossary.md) defines terms used in this documentation.
 
@@ -35,9 +35,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 * This Staging ISLE installation is intended for an existing Production Islandora Drupal site to be imported along with a copy of the current Production Fedora Repository for further ISLE migration testing, Drupal theme development, ingest testing, etc. on a remote ISLE host server.
     * Some materials are to be "migrated" from the work you performed on your personal computer from the prior steps and processes in [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions.
 
-* You will be using ISLE version `1.2.0` or higher
+* You will be using ISLE version **1.2.0** or higher.
 
-* You are using Docker-compose `1.24.0` or higher
+* You are using Docker-compose **1.24.0** or higher.
 
 * You have git installed on your personal computer as well as the remote ISLE host server.
 
@@ -47,9 +47,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
         * [Hardware Requirements](host-hardware-requirements.md)
         * [Software Dependencies](host-software-dependencies.md)
     * This server should be running at the time of deploy.
-    * **Critical** - This `Staging` server has the same amount of disk space as your current Production Fedora server does in order to store a copy of the Fedora repository. Please ensure that these sizes match. Please also plan on adding additional capacity as needed for any potential ingest testing, etc.
+    * **Critical** - This Staging server has the same amount of disk space as your current Production Fedora server does in order to store a copy of the Fedora repository. Please ensure that these sizes match. Please also plan on adding additional capacity as needed for any potential ingest testing, etc.
 
-* You have a previously existing private Islandora Drupal git repository
+* You have a previously existing private Islandora Drupal git repository.
 
 * You have access to a private git repository in [Github](https://github.com), [Bitbucket](https://bitbucket.org/), [Gitlab](https://gitlab.com), etc.
     * If you do not, please contact your IT department for git resources, or else create an account with one of the above providers.
@@ -57,9 +57,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have already have the appropriate A record entered into your institutions DNS system and can resolve the Staging domain (https://yourprojectnamehere-staging.institution.edu) using a tool like https://www.whatsmydns.net/
 
-* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested `Staging` values.
+* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested Staging values.
 
-* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote `Staging` server.
+* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote Staging server.
 
 * You have access to your Production Islandora Drupal, Solr and Fedora data and copy from your servers to the new ISLE Staging server.
 
@@ -69,9 +69,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 ## Index of Instructions
 
-This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the `Staging` ISLE Host server with additional followup work to be performed on the remote `Staging` ISLE Host server.
+This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the Staging ISLE Host server with additional followup work to be performed on the remote Staging ISLE Host server.
 
-The instructions that follow below will have either a `On Local` or a `On Remote Staging` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Staging` and for future ISLE updates and upgrades.
+The instructions that follow below will have either a `On Local` or a `On Remote Staging` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on Staging and for future ISLE updates and upgrades.
 
 **Steps 1-6: On Local - Configure the ISLE Staging Environment Profile for Deploy to Remote**
 
@@ -110,7 +110,7 @@ You are repeating this step given that data may have changed on the Production s
 
 * Drupal website databases can have a multitude of names and conventions. Confer with the appropriate IT departments for your institution's database naming conventions.
 
-* Recommended that the production databases be exported using the `.sql` /or `.gz` file formats e.g. `prod_drupal_site_082019.sql.gz` for better compression and minimal storage footprint.
+* Recommended that the production databases be exported using the `.sql` /or `.gz` file formats (e.g. "prod_drupal_site_082019.sql.gz") for better compression and minimal storage footprint.
 
 * If the end user is running multi-sites, there will be additional databases to export.
 
@@ -121,8 +121,8 @@ You are repeating this step given that data may have changed on the Production s
 #### Export the Production MySQL Islandora Drupal Database
 
 * Export the MySQL database for the current Production Islandora Drupal site in use and copy it to your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your Production site. If you are not comfortable or familiar with performing these actions, we recommend that you instead work with your available IT resources to do so.
-    * You can use a MySQL GUI client for this process or if you have command line access to the MySQL database server
-    `mysqldump -u username -p database_name > prod_drupal_site_082019.sql`
+    * To complete this process, you may use a MySQL GUI client or, if you have command line access to the MySQL database server, you may run the following command, substituting your actual user and database names:
+    * **Example:** `mysqldump -u username -p database_name > prod_drupal_site_082019.sql`
     * Copy this file down to your personal computer.
 
 ---
@@ -132,7 +132,7 @@ You are repeating this step given that data may have changed on the Production s
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
 * Once finished, open a `terminal` (Windows: open `Git Bash`)
-    * Navigate to your local ISLE directory
+    * Navigate to your Local ISLE repository
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
@@ -142,7 +142,7 @@ You are repeating this step given that data may have changed on the Production s
 * Open the "staging.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
-        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Staging` environment but we strongly recommend not reusing all passwords for environments e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment.
+        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this Staging environment but we strongly recommend not reusing all passwords for environments e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment.
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
@@ -155,7 +155,7 @@ You are repeating this step given that data may have changed on the Production s
 
 ## Step 4: On Local - Review and Edit "docker-compose.staging.yml"
 
-* Review the disks and volumes on your remote `Staging` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.staging.yml` file.
+* Review the disks and volumes on your remote Staging ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.staging.yml` file.
 
 * Please read through the `docker-compose.staging.yml` file as there are bind mount points that need to be configured on the host machine, to ensure data persistence. There are suggested bind mounts that the end-user can change to fit their needs or they can setup additional volumes or disks to match the suggestions.
     * In the `fedora` services section
@@ -193,7 +193,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 * _(Optional)_ - This line is already uncommented by default in ISLE but we're calling it out here that you can changes to the suggested levels or values within the `./config/mysql/ISLE.cnf` file if needed. When setting up for the first time, it is best practice to leave these settings in place. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
-* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a `Staging` ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
+* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a Staging ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
 * _(Optional)_ - You can opt to uncomment the TICK stack settings for monitoring but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
     * All TICK related code can be found at the end of all ISLE services within the `docker-compose.staging.yml` file.
@@ -206,7 +206,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
       tag: "{{.Name}}"
 ```
 
-  * Uncomment the lines found in the new TICK stack services section of the `docker-compose.staging.yml` file for hosting of that monitoring service on the `Staging` ISLE Host server.
+  * Uncomment the lines found in the new TICK stack services section of the `docker-compose.staging.yml` file for hosting of that monitoring service on the Staging ISLE Host server.
       * There are additional configurations to be made to files contained within `./config/tick` but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
   * Uncomment the TICK stack data volumes as well at the bottom of the file.
 
@@ -247,7 +247,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ## Step 6: On Local - Commit ISLE Code to Git Repository
 
-* Once you have made all of the appropriate changes to your `Staging` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
+* Once you have made all of the appropriate changes to your Staging profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
     * `git commit -m "Changes for Staging"`
     * `git push origin master`
@@ -264,9 +264,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 Since the `/opt` directory might not let you do this at first, we suggest the following workaround which you'll only need to do once. Future ISLE updates will not require this step.
 
-* Shell into your `Staging` ISLE host server as the `Islandora` user.
+* Shell into your Staging ISLE host server as the `Islandora` user.
 
-* Clone your ISLE project repository with the newly committed changes for `Staging` to the `Islandora` user home directory.
+* Clone your ISLE project repository with the newly committed changes for Staging to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
     * This may take a few minutes (2-4) depending on your server's Internet connection.
 
@@ -303,17 +303,17 @@ Please clone from your existing Production Islandora git repository.
 * It is recommended that you schedule a content freeze for all Production Fedora ingests and additions to your Production website. This will allow you to get up to date data from Production to Staging.
 
 * As you may have made some critical decisions potentially from "Step 0: Copy Production Data to Your Local" of the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) instructions, you need to re-follow the steps to get your:
-    * `Production` Drupal site `files` directory
+    * Production Drupal site `files` directory
     * `Solr schema & Islandora transforms`
         * If you picked **Easy** option:
           * then you don't need to do anything here for the `Solr schema & Islandora transforms`
         * If you picked the **Intermediate** or **Advanced** options:
           * You'll need to copy in the customizations and files you created during the `local` environment into the `docker-compose.staging.yml`. Ensure that one set of transforms and schema are used across all environments.
-    * `Production` Fedora `datastreamStore` directory
+    * Production Fedora `datastreamStore` directory
         * You'll need to adjust the paths below in case your setup differs on either the non-ISLE Production server or the ISLE Staging server.
         * Copy your `/usr/local/fedora/data/datastreamStore` data to the suggested path of `/mnt/data/fedora/datastreamStore`
             * You may need to change the permissions to `root:root` on the Staging `/mnt/data/fedora/datastreamStore` directory above after copying so the Fedora container can access properly. Do not do this on your existing Production system please.
-    * `Production` Fedora `objectStore`. 
+    * Production Fedora `objectStore`. 
         * Copy your `/usr/local/fedora/data/objectStore` data to the suggested path of `/opt/data/fedora/objectStore`
             * You may need to change the permissions to `root:root` on the Staging `/opt/data/fedora/objectStore` above after copying so the Fedora container can access properly. Do not do this on your existing Production system please.
 
@@ -386,7 +386,7 @@ fatal: empty ident name (for <islandora@yourprojectnamehere-staging.institution.
 ```
 
 * Configure your server git client but don't use the `--global` setting as that could interfere with other git repositories e.g. your Islandora Drupal code.
-    * Example: Within `/opt/yourprojectnamehere`
+    * **Example:** Within `/opt/yourprojectnamehere`
     * `git config user.email "jane@institution.edu"`
     * `git config user.name "Jane Doe"`
 
@@ -445,11 +445,11 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Staging server.
 
-* Import the exported `Local` MySQL database for use in the current `Staging` Drupal site. Refer to your `staging.env` for the usernames and passwords used below.
+* Import the exported Local MySQL database for use in the current Staging Drupal site. Refer to your `staging.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
     * _Using the same open terminal:_  
-    * Shell into your currently running "Staging" MySQL container
+    * Shell into your currently running Staging MySQL container
         * `docker exec -it your-mysql-containername bash`
     * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "staging.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
@@ -473,7 +473,7 @@ This step will show you how to run the "migration_site_vsets.sh" script on the A
 * Run the script
     * `docker exec -it your-apache-containername bash -c "cd /var/www/html && ./migration_site_vsets.sh"`
 
-This step will show you how to shell into your currently running "Staging" Apache container, and run the "fix-permissions.sh" script to fix the Drupal site permissions.
+This step will show you how to shell into your currently running Staging Apache container, and run the "fix-permissions.sh" script to fix the Drupal site permissions.
 
 * `docker exec -it your-apache-containername bash`
 * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
@@ -512,7 +512,7 @@ Since this command can take minutes or hours depending on the size of your repos
 
 **Please note:** The method described below is a longer way of doing this process to onboard users.
 
-* Shell into your currently running "Staging" Fedora container
+* Shell into your currently running Staging Fedora container
     * Run `docker ps` to determine the Fedora container name
     * `docker exec -it your-fedora-containername bash`
 
@@ -562,7 +562,7 @@ Find logs at /usr/local/tomcat/logs/fgs-update-foxml.out and /usr/local/tomcat/l
 You can watch log file 'tail -f /usr/local/tomcat/logs/fedoragsearch.daily.log' as the process runs.
 ```
 
-**Please note:** Within this output, options to tail logs and watch progress are offered. Depending on the size of your collection this process may take hours, however it is okay to exit out of the container and even log off the remote `Staging` server. You can check back frequently by running `tail -f /usr/local/tomcat/logs/fgs-update-foxml.out` on the Fedora container. If you visit your Drupal site and run a Solr search, you should start to see objects and facets start to work. The number of objects will increase over time.
+**Please note:** Within this output, options to tail logs and watch progress are offered. Depending on the size of your collection this process may take hours, however it is okay to exit out of the container and even log off the remote Staging server. You can check back frequently by running `tail -f /usr/local/tomcat/logs/fgs-update-foxml.out` on the Fedora container. If you visit your Drupal site and run a Solr search, you should start to see objects and facets start to work. The number of objects will increase over time.
 
 * After a good period of time, again depending on the size of your Fedora collection, when the Solr re-index process finishes, output like the example below will appear in the `/usr/local/tomcat/logs/fgs-update-foxml.out` log. This indicates that the Solr reindex process was completed. The number of objects rebuilt will vary. You can hit the CNTRL and C keys to exit out of the tail process, if need be.
 
@@ -588,10 +588,10 @@ Args
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
 * Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "staging.env".
-    * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
+    * **Please note:** You are free to use previously Drupal admin or user accounts created during the Local site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.
-    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous `Local` installation.
+    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous Local installation.
 
 ---
 
@@ -604,8 +604,8 @@ Once you are ready to deploy your finished Drupal site, you may progress to:
 ---
 
 ## Additional Resources
-* [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `local.env`, etc.
-* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator tools.
+* [ISLE Installation: Environments](../install/install-environments.md) help with explaining the ISLE structure, the associated files, and what values ISLE end-users should use for the ".env", "local.env", etc.
+* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator testing.
 * [ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/install-staging-new.md
+++ b/docs/install/install-staging-new.md
@@ -2,11 +2,11 @@
 
 _Expectations:  It takes an average of **2-4+ hours** to read this documentation and complete this installation._
 
-This `Staging` ISLE Installation will use the themed Drupal website created during the [Local ISLE Installation: New Site](../install/install-local-new.md) process and will create an empty Fedora repository for remote (non-local / cloud) hosting of a `Staging` site. Islandora Drupal site code here should be considered almost finished but hosted here for last touches and team review privately prior to pushing to public `Production`. Fedora data might have tests collections or collections that should then be synced to the `Production` site. It is recommended that this remote site not be publicly accessible.
+This Staging ISLE Installation will use the themed Drupal website created during the [Local ISLE Installation: New Site](../install/install-local-new.md) process and will create an empty Fedora repository for remote (non-local or cloud) hosting of a Staging site. Islandora Drupal site code here should be considered almost finished but hosted here for last touches and team review privately prior to pushing to public Production. Fedora data might have tests collections or collections that should then be synced to the Production site. It is recommended that this remote site not be publicly accessible.
 
-While this installation will get you a brand new `Staging` site, it is **not** intended as a migration process of a previously existing Islandora site. If you need to build a `Staging` environment to migrate a previously existing Islandora site, please use the [Staging ISLE Installation: Migrate Existing Islandora Site](../install/install-staging-migrate.md) instructions instead.
+While this installation will get you a brand new Staging site, it is **not** intended as a migration process of a previously existing Islandora site. If you need to build a Staging environment to migrate a previously existing Islandora site, please use the [Staging ISLE Installation: Migrate Existing Islandora Site](../install/install-staging-migrate.md)  instead.
 
-As this `Staging` domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your `Staging` Host Server IP address in your institution's DNS records. We recommend that this sub-domain use `-staging` to differentiate it from the Production site.
+As this Staging domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your Staging Host Server IP address in your institution's DNS records. We recommend that this sub-domain use `-staging` to differentiate it from the Production site.
 
 Example:`https://yourprojectnamehere-staging.institution.edu`
 
@@ -14,7 +14,7 @@ Once this has been completed, if you do not want to use Let's Encrypt, you can a
 
 Unlike the Local and Demo setups, you will not have to edit `/etc/localhosts` to view your domain given that DNS is now involved. Your new domain will no longer use the `.localdomain` but instead something like `https://yourprojectnamehere-staging.institution.edu`
 
-This document also has directions on how you can check in newly created ISLE and Islandora code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging and finally to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `staging.env`, etc.
+This document also has directions on how you can save newly created ISLE and Islandora code into a git software repository as a workflow process designed to manage and upgrade the environments throughout the development process from Local to Staging to Production. The [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `staging.env`, etc.
 
 Please post questions to the public [Islandora ISLE Google group](https://groups.google.com/forum/#!forum/islandora-isle), or subscribe to receive emails. The [Glossary](../appendices/glossary.md) defines terms used in this documentation.
 
@@ -23,9 +23,9 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 * This Staging ISLE installation is intended for a brand new ISLE site for further Drupal theme development, ingest testing, etc. on a remote ISLE host server.
     * All materials are to be "migrated" from the work you performed on your personal computer from the prior steps and processes in [Local ISLE Installation: New Site](../install/install-local-new.md) instructions.
 
-* You will be using ISLE version `1.2.0` or higher
+* You will be using ISLE version **1.2.0** or higher.
 
-* You are using Docker-compose `1.24.0` or higher
+* You are using Docker-compose **1.24.0** or higher.
 
 * You have git installed on your personal computer as well as the remote ISLE host server.
 
@@ -43,17 +43,17 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * You have already have the appropriate A record entered into your institutions DNS system and can resolve the Staging domain (https://yourprojectnamehere-staging.institution.edu) using a tool like https://www.whatsmydns.net/
 
-* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested `Staging` values.
+* You have reviewed the [ISLE Installation: Environments](../install/install-environments.md) for more information about suggested Staging values.
 
-* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote `Staging` server.
+* You are familiar with using tools like `scp, cp or rsync` to move configurations, files and data from your local to the remote Staging server.
 
 ---
 
 ## Index of Instructions
 
-This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the `Staging` ISLE Host server with additional followup work to be performed on the remote `Staging` ISLE Host server.
+This process will differ slightly from previous builds in that there is work to be done on the local to then be pushed to the Staging ISLE Host server with additional followup work to be performed on the remote Staging ISLE Host server.
 
-The instructions that follow below will have either a `On Local` or a `On Remote Staging` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on `Staging` and for future ISLE updates and upgrades.
+The instructions that follow below will have either a `On Local` or a `On Remote Staging` pre-fix to indicate where the work and focus should be. In essence, the git workflow established during the local build process will be extended for deploying on Staging and for future ISLE updates and upgrades.
 
 **Steps 1-6: On Local - Configure the ISLE Staging Environment Profile for Deploy to Remote**
 
@@ -96,7 +96,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 ### Export the Local MySQL Islandora Drupal Database
 
-* Export the MySQL database for the current `Local` Drupal site in use and copy it on your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your newly created and themed new Islandora site. Refer to your `local.env` for the usernames and passwords used below.
+* Export the MySQL database for the current Local Drupal site in use and copy it on your local in an easy to find place. In later steps you'll be directed to import this file. **Please be careful** performing any of these potential actions below as the process impacts your newly created and themed new Islandora site. Refer to your `local.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Shell into your currently running Local MySQL container
         * `docker exec -it your-mysql-containername bash`
@@ -114,7 +114,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 * Ensure that your ISLE and Islandora git repositories have all the latest commits and pushes from the development process that took place on your personal computer. If you haven't yet finished, do not proceed until everything is completed.
 
 * Once finished, open a `terminal` (Windows: open `Git Bash`)
-    * Navigate to your local ISLE directory
+    * Navigate to your Local ISLE repository
     * Shut down any local containers e.g. `docker-compose down`
 
 ---
@@ -124,7 +124,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 * Open the "staging.env" file in a text editor.
     * Find each comment that begins with: `# Replace this comment with a ...` and follow the commented instructions to edit the passwords, database and user names.
         * **Review carefully** as some comments request that you replace with `...26 alpha-numeric characters` while others request that you create an `...easy to read but short database name`.
-        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this `Staging` environment but we strongly recommend not reusing all passwords for environments e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment.
+        * It is okay if you potentially repeat the values previously entered for your local `(DRUPAL_DB)` & `(DRUPAL_DB_USER)` in this Staging environment but we strongly recommend not reusing all passwords for environments e.g. `(DRUPAL_DB_PASS)` & `(DRUPAL_HASH_SALT)` should be unique values for each environment.
         * In many cases the username is already pre-populated. If it doesn't have a comment directing you to change or add a value after the `=`, then don't change it.
     * Once finished, save and close the file.
 
@@ -137,7 +137,7 @@ The instructions that follow below will have either a `On Local` or a `On Remote
 
 ## Step 4: On Local - Review and Edit "docker-compose.staging.yml"
 
-* Review the disks and volumes on your remote `Staging` ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.staging.yml` file.
+* Review the disks and volumes on your remote Staging ISLE Host server to ensure they are of an adequate capacity for your collection needs and match what has been written in the `docker-compose.staging.yml` file.
 
 * Please read through the `docker-compose.staging.yml` file as there are bind mount points that need to be configured on the host machine, to ensure data persistence. There are suggested bind mounts that the end-user can change to fit their needs or they can setup additional volumes or disks to match the suggestions.
     * In the `fedora` service section
@@ -169,7 +169,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
 
 * _(Optional)_ - This line is already uncommented by default in ISLE but we're calling it out here that you can changes to the suggested levels or values within the `./config/mysql/ISLE.cnf` file if needed. When setting up for the first time, it is best practice to leave these settings in place. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
-* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a `Staging` ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
+* _(Optional)_ - You can change the suggested `JAVA_MAX_MEM` & `JAVA_MIN_MEM` levels but do not exceed more than 50% of your system memory. When setting up for the first time, it is best practice to leave these settings in place as they are configured for a Staging ISLE Host Server using 16 GB of RAM. Over time, you can experiment with further tuning and experimentation based on your project or system needs.
 
 * _(Optional)_ - You can opt to uncomment the TICK stack settings for monitoring but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
     * All TICK related code can be found at the end of all ISLE services within the `docker-compose.staging.yml` file.
@@ -182,7 +182,7 @@ The options include PHP settings, Java Memory Allocation, MySQL configuration an
       tag: "{{.Name}}"
 ```
 
-  * Uncomment the lines found in the new TICK stack services section of the `docker-compose.staging.yml` file for hosting of that monitoring service on the `Staging` ISLE Host server.
+  * Uncomment the lines found in the new TICK stack services section of the `docker-compose.staging.yml` file for hosting of that monitoring service on the Staging ISLE Host server.
       * There are additional configurations to be made to files contained within `./config/tick` but you'll need to follow the [TICK Stack](../optional-components/tickstack.md) instructions prior to committing changes to your ISLE git repository.
   * Uncomment the TICK stack data volumes as well at the bottom of the file.
 
@@ -223,7 +223,7 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 ## Step 6: On Local - Commit ISLE Code to Git Repository
 
-* Once you have made all of the appropriate changes to your `Staging` profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
+* Once you have made all of the appropriate changes to your Staging profile. Please note the steps below are suggestions. You might use a different git commit message. Substitute `<changedfileshere>` with the actual file names and paths. You may need to do this repeatedly prior to the commit message.
     * `git add <changedfileshere>`
     * `git commit -m "Changes for Staging"`
     * `git push origin master`
@@ -240,9 +240,9 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 Since the `/opt` directory might not let you do this at first, we suggest the following workaround which you'll only need to do once. Future ISLE updates will not require this step.
 
-* Shell into your `Staging` ISLE host server as the `Islandora` user.
+* Shell into your Staging ISLE host server as the `Islandora` user.
 
-* Clone your ISLE project repository with the newly committed changes for `Staging` to the `Islandora` user home directory.
+* Clone your ISLE project repository with the newly committed changes for Staging to the `Islandora` user home directory.
     * `git clone https://yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-isle.git /home/islandora/`
     * This may take a few minutes (2-4) depending on your server's Internet connection.
 
@@ -350,7 +350,7 @@ fatal: empty ident name (for <islandora@yourprojectnamehere-staging.institution.
 ```
 
 * Configure your server git client but don't use the `--global` setting as that could interfere with other git repositories e.g. your Islandora Drupal code.
-    * Example: Within `/opt/yourprojectnamehere`
+    * **Example:** Within `/opt/yourprojectnamehere`
     * `git config user.email "jane@institution.edu"`
     * `git config user.name "Jane Doe"`
 
@@ -409,10 +409,10 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 * Copy the `local_drupal_site_082019.sql` created in Step 1 to the Remote Staging server.
 
-* Import the exported `Local` MySQL database for use in the current `Staging` Drupal site. Refer to your `staging.env` for the usernames and passwords used below.
+* Import the exported Local MySQL database for use in the current Staging Drupal site. Refer to your `staging.env` for the usernames and passwords used below.
     * You can use a MySQL GUI client for this process instead but the command line directions are only included below.
     * Run `docker ps` to determine the MySQL container name
-    * Shell into your currently running "Staging" MySQL container
+    * Shell into your currently running Staging MySQL container
         * `docker exec -it your-mysql-containername bash`
     * Import the Local Islandora Drupal database. Replace the "DRUPAL_DB_USER" and "DRUPAL_DB" in the command below with the values found in your "staging.env" file.
         * `mysql -u DRUPAL_DB_USER -p DRUPAL_DB < local_drupal_site_082019.sql`
@@ -426,7 +426,7 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 
 * You'll need to fix the Drupal site permissions by running the `/fix-permissions.sh` script from the Apache container
     * Run `docker ps` to determine the Apache container name
-    * Shell into your currently running "Staging" Apache container
+    * Shell into your currently running Staging Apache container
         * `docker exec -it your-apache-containername bash`
         * `sh /utility-scripts/isle_drupal_build_tools/drupal/fix-permissions.sh --drupal_path=/var/www/html --drupal_user=islandora --httpd_group=www-data`
         * This process will take 2-5 minutes
@@ -441,7 +441,7 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
 | - Allow vpnkit.exe to communicate with the network.  Click Okay or Allow (accept default selection).|
 | - If the process seems to halt, check the taskbar for background windows.|
 
-* **Proceed only after this message appears:** "Clearing Drupal Caches. 'all' cache was cleared."
+* **Proceed only after this message appears:** "Done. 'all' cache was cleared."
 
 ---
 
@@ -451,10 +451,10 @@ git commit -m "Added the edited .env configuration file for Staging. DO NOT PUSH
     * Please note: You should not see any errors with respect to the SSL certifications. If so, please review your previous steps especially if using Let's Encrypt. You may need to repeat those steps to get rid of the errors.
 
 * Log in to the local Islandora site with the credentials ("DRUPAL_ADMIN_USER" and "DRUPAL_ADMIN_PASS") you created in "staging.env".
-    * **Please note:** You are free to use previously Drupal admin or user accounts created during the `Local` site development process.
+    * **Please note:** You are free to use previously Drupal admin or user accounts created during the Local site development process.
 
 * You can decide to further QC and review the site as you wish or start to add digital collections and objects.
-    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous `Local` installation.
+    * You could also further test using the [Islandora Sample Objects](https://github.com/Islandora-Collaboration-Group/islandora-sample-objects) as you may have done in the previous Local installation.
 
 ---
 
@@ -467,8 +467,8 @@ Once you are ready to deploy your finished Drupal site, you may progress to:
 ---
 
 ## Additional Resources
-* [ISLE Installation: Environments](../install/install-environments.md) documentation can also help with explaining the new ISLE structure, the associated files and what values ISLE end-users should use for the `.env`, `local.env`, etc.
-* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator tools.
+* [ISLE Installation: Environments](../install/install-environments.md) help with explaining the ISLE structure, the associated files, and what values ISLE end-users should use for the ".env", "local.env", etc.
+* [Local ISLE Installation: Resources](../install/install-local-resources.md) contains Docker container passwords and URLs for administrator testing.
 * [ISLE Installation: Troubleshooting](../install/install-troubleshooting.md) contains help for port conflicts, non-running Docker containers, etc.
 
 ---

--- a/docs/install/install-troubleshooting.md
+++ b/docs/install/install-troubleshooting.md
@@ -14,7 +14,7 @@
 If you encounter an error like this:
 
 * Set up an SSH key and add it to your local ssh-agent to add access rights to read from your remote repository.
-* This will allow you to pull from your git repository provider / hoster. 
+* This will allow you to pull from your git repository hosting service. 
 * See SSH key "How To" instructions on [Github](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) or [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html) or [Gitlab](https://docs.gitlab.com/ee/ssh/).
 
 ---

--- a/docs/optional-components/blazegraph.md
+++ b/docs/optional-components/blazegraph.md
@@ -405,7 +405,7 @@ Checking the triples count is an easy way to double-check if objects are being i
 To check the triples count in Blazegraph:
 
 * Navigate to the Blazegraph Admin panel http://isle.localdomain:8084/blazegraph/#query
-  * Replace `isle.localdomain` with your real domain when using in `Staging` or `Production`
+  * Replace `isle.localdomain` with your real domain when using in Staging or Production
 
 * Copy and paste the following query into the field with the text (_Input a SPARQL query_):
 

--- a/docs/optional-components/tickstack.md
+++ b/docs/optional-components/tickstack.md
@@ -102,7 +102,7 @@ The use and setup of TICK within the ISLE platform is as an optional [sidecar](h
 The Telegraf agent used for ISLE has a default configuration which runs the following plugins to monitor various services whether it is on a Production or Staging system.
 
 There are three `.conf` files found within `./config/tick/telegraf`
-  * `telegraf.conf` - Use this as a genric configuration for any system you'd like to monitor. Use this template file as a method to monitor ISLE environments that are not `Staging` or `Production`
+  * `telegraf.conf` - Use this as a genric configuration for any system you'd like to monitor. Use this template file as a method to monitor ISLE environments that are not Staging or Production
   * `telegraf.staging.conf` - Edit this file to run a full TICK stack on your ISLE Staging server which can monitor both your Staging and Production systems. 
   * `telegraf.production.conf` - Edit this file to point to your full TICK stack running on your ISLE Staging server.
 
@@ -145,9 +145,9 @@ If an ISLE User would like to add a plugin to monitor additional services, pleas
 
 ## Adoption Process Overview
 
-The installation instructions below will walk you through how to run the full TICK stack on a `Staging` ISLE host system but only run  a Telegraf container (agent) on the `Production` system. This will be referred to from now on as the "sidecar" setup.
+The installation instructions below will walk you through how to run the full TICK stack on a Staging ISLE host system but only run  a Telegraf container (agent) on the Production system. This will be referred to from now on as the "sidecar" setup.
 
-The data from both systems will be collected, analyzed and accessed on / from the the `Staging` host system via a dashboard called Chronograf. You can also setup alerts from this dashboard too.
+The data from both systems will be collected, analyzed and accessed on / from the the Staging host system via a dashboard called Chronograf. You can also setup alerts from this dashboard too.
 
 * You'll start by backing up all important data as needed.
 
@@ -168,15 +168,15 @@ The data from both systems will be collected, analyzed and accessed on / from th
     * `staging.env`
     * `production.env`  
 
-* You'll edit the `Staging` Telegraf Agent's empty or default settings to properly monitor the various local ISLE services and send metrics to the local Influxdb database on the Staging system.
+* You'll edit the Staging Telegraf Agent's empty or default settings to properly monitor the various local ISLE services and send metrics to the local Influxdb database on the Staging system.
 
 * You'll restart your containers with the new services having been added and configured.
 
-* Using a web browser, you'll navigate to the new Chronograf dashboard on the `Staging` server and complete the configuration of the Influxdb, Chronograf and Kapacitor services.
+* Using a web browser, you'll navigate to the new Chronograf dashboard on the Staging server and complete the configuration of the Influxdb, Chronograf and Kapacitor services.
     * You'll have the option to create new dashboards
     * If desired, you'll add additional alerts
 
-- You'll repeat the steps to edit the Telegraf Agent's configuration for your `Production` system only. You do not need to install the remaining "ICK" stack on `Production` though.
+- You'll repeat the steps to edit the Telegraf Agent's configuration for your Production system only. You do not need to install the remaining "ICK" stack on Production though.
 
 * You can then review the `Using Chronograf` section to learn how to review the new added hosts, dashboards and Log Viewer to review ISLE services log streams.
 
@@ -218,7 +218,7 @@ The data from both systems will be collected, analyzed and accessed on / from th
 * Check if you already have an existing `/etc/docker/daemon.json` file. 
     * If **YES**, add / merge  the contents of `./config/tick/docker/daemon.json` with your current `/etc/docker/daemon.json` file.
     * If **NO**, copy `./config/tick/docker/daemon.json` to `/etc/docker/`
-        * Example: `sudo cp ./config/tick/docker/daemon.json /etc/docker/`
+        * **Example:** `sudo cp ./config/tick/docker/daemon.json /etc/docker/`
 
 * Restart the Docker service
     * `sudo service docker restart` or `sudo systemctl restart docker`
@@ -354,7 +354,7 @@ The instructions to setup only the Telegraf Agent on an ISLE system e.g. your Pr
     * `database = "telegraf"`
         * By default, the ISLE TICK setup assumes this database as it is the easiest but pools all data received by individual monitored hosts into one database. For first time users, recommend leaving this value in place.
         * Users are free to change this to any value to segregate data by systems, group etc.
-    * Change `servers = ["root:<ISLE_ROOT_PASSWORD_HERE>@tcp(mysql:3306)/?tls=false"]` to use your `Staging` MySQL Root password. Typically this value is in your `staging.env` file. Swap out the `<ISLE_ROOT_PASSWORD_HERE>` with your `Staging` MySQL Root password.
+    * Change `servers = ["root:<ISLE_ROOT_PASSWORD_HERE>@tcp(mysql:3306)/?tls=false"]` to use your Staging MySQL Root password. Typically this value is in your `staging.env` file. Swap out the `<ISLE_ROOT_PASSWORD_HERE>` with your Staging MySQL Root password.
 
 
 * Start up the ISLE Docker containers again. `docker-compose up -d`
@@ -441,7 +441,7 @@ Aug 13 17:24:49 ip-172-31-69-204 rsyslogd[28257]:  [origin software="rsyslogd" s
 
 #### Adoption Process Overview
 
-* Use these instructions to add an additional Docker Telegraf container on a `Production` system. Once you've followed the instructions below, a new `Production` host will appear in your Chronograf dashboard for you to review alongside your previously configured `Staging` host.
+* Use these instructions to add an additional Docker Telegraf container on a Production system. Once you've followed the instructions below, a new Production host will appear in your Chronograf dashboard for you to review alongside your previously configured Staging host.
 
 #### Assumptions
 
@@ -449,15 +449,15 @@ Aug 13 17:24:49 ip-172-31-69-204 rsyslogd[28257]:  [origin software="rsyslogd" s
 
 * You'll need to use ISLE version `1.2.0` for the syslog driver changes to be in place.
 
-* That the "sidecar" TICK installation is already in place on the `Staging` server prior.
+* That the "sidecar" TICK installation is already in place on the Staging server prior.
 
 * Your firewall allows outbound port `8086` traffic
 
 ####  Installation
 
-In the recommended setup and usage of TICK, the `Staging` server will be running the full stack of TICK as a collection point for all `Staging` data and any `Production` system will only need the Telegraf agent installed.
+In the recommended setup and usage of TICK, the Staging server will be running the full stack of TICK as a collection point for all Staging data and any Production system will only need the Telegraf agent installed.
 
-To install the Telegraf agent on a `Production` system:
+To install the Telegraf agent on a Production system:
 
 * Shut down all running ISLE containers on the Production system
 
@@ -465,12 +465,12 @@ To install the Telegraf agent on a `Production` system:
     * `hostname = ""`
         * Enter the name of the server you will be monitoring e.g. `isle-server-prod` or `icg-production` etc. This value can be a [FQDN](https://kb.iu.edu/d/aiuv) i.e. `production-server.domain.edu`, an IP or any name really. Recommend a short name to be easily read and understood.
     * `urls = ["http://influxdb:8086"]`
-        * Replace the `influxdb` value with the [FQDN](https://kb.iu.edu/d/aiuv) of the `Staging` server that is running the full TICK stack and that this Telegraf agent will be sending data to e.g.
+        * Replace the `influxdb` value with the [FQDN](https://kb.iu.edu/d/aiuv) of the Staging server that is running the full TICK stack and that this Telegraf agent will be sending data to e.g.
       `urls = ["http://staging-server.domain.edu:8086"]`
     * `database = "telegraf"`
         * By default, the ISLE TICK setup assumes this database as it is the easiest but pools all data received by individual monitored hosts into one database. For first time users, recommend leaving this value in place.
         * Users are free to change this to any value to segregate data by systems, group etc.
-    * Change `servers = ["root:<ISLE_ROOT_PASSWORD_HERE>@tcp(mysql:3306)/?tls=false"]` to use your `Production` MySQL Root password. Typically this value is in your `production.env` file. Swap out the `<ISLE_ROOT_PASSWORD_HERE>` with your `Production` MySQL Root password.
+    * Change `servers = ["root:<ISLE_ROOT_PASSWORD_HERE>@tcp(mysql:3306)/?tls=false"]` to use your Production MySQL Root password. Typically this value is in your `production.env` file. Swap out the `<ISLE_ROOT_PASSWORD_HERE>` with your Production MySQL Root password.
 
 
 #### Edits - docker-compose.production.yml file 
@@ -506,17 +506,17 @@ Uncommented example:
 ```
 
 * Copy the Telegraf configuration file to the Rsyslog.d directory so Rsyslog will forward logs to the Telegraf agent with correct formatting. Assumes you are in the ISLE project root directory.
-    * Example: `sudo cp ./config/tick/rsyslog/50-telegraf.conf /etc/rsyslog.d/50-telegraf.conf`
+    * **Example:** `sudo cp ./config/tick/rsyslog/50-telegraf.conf /etc/rsyslog.d/50-telegraf.conf`
 
 * Copy over the Docker log driver configuration and then restart the Docker service.
-    * Example: `sudo cp ./config/tick/docker/daemon.json /etc/docker/daemon.json`
+    * **Example:** `sudo cp ./config/tick/docker/daemon.json /etc/docker/daemon.json`
     * `sudo service docker restart`
 
 * Start up the ISLE Docker containers again. `docker-compose up -d`
 
 * Depending on your internet connection, this startup process may take a few minutes, as the new TICK images are being downloaded and started.
 
-* Once the `Production` containers are back online, the services are running e.g. you see the Drupal site, etc. navigate to the `Hosts` section within the `Chronograf` dashboard. You should now see your new `Production` server name. This means the Telegraf Agent on your `Production` ISLE system is now reporting properly. 
+* Once the Production containers are back online, the services are running e.g. you see the Drupal site, etc. navigate to the `Hosts` section within the `Chronograf` dashboard. You should now see your new Production server name. This means the Telegraf Agent on your Production ISLE system is now reporting properly. 
 
 ---
 
@@ -524,7 +524,7 @@ Uncommented example:
 
 If you are not seeing your server(s) appear in the `Hosts` section nor seeing log information flowing into the `Log Viewer` section, recommend the following:
 
-* Check that any potential firewalls are allowing communication between the `Production` and `Staging` servers on port `8086`
+* Check that any potential firewalls are allowing communication between the Production and Staging servers on port `8086`
 
 * Ensure that all configuration files have been copied over:
     * The new Docker log driver configuration should be found here `/etc/docker/daemon.json`
@@ -533,7 +533,7 @@ If you are not seeing your server(s) appear in the `Hosts` section nor seeing lo
 * Check that the TICK related containers are running without exit codes. 
     * `docker ps -a`
   
-* Check that the new `Telegraf` docker container is running on `Production`
+* Check that the new `Telegraf` docker container is running on Production
 
 * You can check if the Telegraf agent is communicating properly with the Influxdb database and if the Influxdb database is running by using the following command in your terminal:
 

--- a/docs/release-notes/release-1-2-0.md
+++ b/docs/release-notes/release-1-2-0.md
@@ -65,9 +65,9 @@ COMPOSE_FILE=docker-compose.demo.yml
 
 * All other users, names and passwords from your previous ISLE 1.1.1 & 1.1.2 `.env` will now need to be copied into the new environment .env files
   * `demo.env` - Prepopulated. Nothing to change.
-  * `local.env` - Copy over all users, names and passwords from your previous `Local` ISLE 1.1.1 & 1.1.2 `.env` to the appropriate variable. Remove the comments and replace with the appropriate `Local` values.
-  * `staging.env` - Copy over all users, names and passwords from your previous `Staging` ISLE 1.1.1 & 1.1.2 `.env` to the appropriate variable. Remove the comments and replace with the appropriate `Staging` values.
-  * `production.env` - Copy over all users, names and passwords from your previous `Production` ISLE 1.1.1 & 1.1.2 `.env` to the appropriate variable. Remove the comments and replace with the appropriate `Production` values.
+  * `local.env` - Copy over all users, names and passwords from your previous Local ISLE 1.1.1 & 1.1.2 `.env` to the appropriate variable. Remove the comments and replace with the appropriate Local values.
+  * `staging.env` - Copy over all users, names and passwords from your previous Staging ISLE 1.1.1 & 1.1.2 `.env` to the appropriate variable. Remove the comments and replace with the appropriate Staging values.
+  * `production.env` - Copy over all users, names and passwords from your previous Production ISLE 1.1.1 & 1.1.2 `.env` to the appropriate variable. Remove the comments and replace with the appropriate Production values.
 
 * `docker-compose.yml` - This file no longer exists in ISLE 1.2.0 and has been replaced by new docker-compose files and environment profiles created for:
   * **Demo** - `docker-compose.demo.yml` - use this to spin up ISLE quickly just to check it out.

--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -1,110 +1,125 @@
-# Update ISLE
+# Update ISLE to the Latest Release
 
 Update an existing ISLE installation to install the newest improvements and security updates. This process is intended to be backwards compatible with your existing ISLE site.
 
-**Important information:**
+We strongly recommend that you begin the update process on your Local environment so that you may test and troubleshoot before proceeding to update your Staging and Production environments.
 
-- These instructions assume you have already installed a version of ISLE using git whether you used the [Local ISLE Installation: New Site](../install/install-local-new.md) or the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) on your local personal computer.
-- As with any enterprise system, it is strongly suggested you run these update steps in a test environment before updating your production server.
-- Please always read the latest [Release Notes](../release-notes/release-1-1-2.md).
-- Docker Desktop Update: If Docker alerts you that updates are available for your personal computer, please follow these steps:
-    1. Go to your local ISLE site: `docker-compose down`
-    2. Install the new updated version of Docker Desktop.
-    3. Go to your local ISLE site: `docker-compose up -d`
+## Important Information
 
-**Update your version of ISLE to the latest release:**
+- These instructions assume you have already installed either the [Local ISLE Installation: New Site](../install/install-local-new.md) or the [Local ISLE Installation: Migrate Existing Islandora Site](../install/install-local-migrate.md) on your Local personal computer and are using that described git workflow.
+- Please test these updates on your Local and Staging environments before updating your Production server.
+- Always read the [Release Notes](../release-notes/release-1-1-2.md) for any version(s) newer than that which you are currently running.
+- **Docker Desktop Update:** If Docker prompts that updates are available for your personal computer, please follow these steps:
+    1. Go to your Local ISLE site: `docker-compose down`
+    2. Install the new updated version(s) of Docker Desktop.
+    3. Go to your Local ISLE site: `docker-compose up -d`
 
-We strongly recommend that you start the update process on your `Local` environment first to determine what type of testing is required for your projects, troubleshoot any issues and make any necessary adjustments or merges from the git code.
+## Update Local (personal computer)
 
-On your Local version of ISLE:
+* On your Local (personal computer), open a terminal (Windows: open Git Bash) and navigate to your Local ISLE repository (this contains the "docker-compose.local.yml" file):
+    * **Example:** `cd /path/to/your/repository`
 
-* In the command line (Windows: open Git Bash), navigate to the ISLE directory, which should contain the `docker-compose.local.yml` file.
-
-* Stop and remove your existing ISLE containers
+* Stop and remove the existing ISLE containers:
     * `docker-compose down`
 
-* Check your git remotes: `git remote -v`
-    * If you do not have a remote named `icg-upstream` then do this:
+* Check your git remotes:
+    * `git remote -v`
+* If you do not have a remote named "icg-upstream" then create one:
     * `git remote add icg-upstream https://github.com/Islandora-Collaboration-Group/ISLE.git`
 
-* Run a git fetch from the ICG upstream
+* Run a git fetch from the ICG upstream:
     * `git fetch icg-upstream`
 
-* Checkout a new git branch as a precaution for performing the update on your project. This way your `master` branch stays safe and untouched until you have tested thoroughly and are ready to merge in changes from the recent update. The new local branch can be anything. An example is given below.
-    * `git checkout isle-update-numberhere`
+* Checkout a new git branch as a precaution for performing the update on your project. This way your "master" branch stays safe and untouched until you have tested thoroughly and are ready to merge in changes from the recent update. You may select any name for your new local branch.
+    * **Example:** `git checkout -b isle-update-numberhere`
 
-* Pull down the ICG ISLE `master` branch into your local project's new `isle-update-numberhere` branch
+* Pull down the ICG ISLE "master" branch into your Local project's new "isle-update-numberhere" branch:
     * `git pull icg-upstream master`
-    * if you `ls -lha` in this directory, you'll now have code.
-
-* You'll need to use an text editor or IDE to determine if there are git merges to be worked out. Large ISLE point releases e.g. `1.1.2` to `1.2.0` will more than likely introduce merge conflicts and breaking changes. Move through this update process slowly and carefully. Changes will usually include but are not limited to:
+* In your ISLE directory, you may view the newest release of ISLE code by entering:
+    * `ls -lha`
+* Now that you have pulled down the latest code, there are likely to be conflicts between your existing code and the newer code. Run this command to determine if there are git merge conflicts:
+    * `git status`
+* If there are any merge conflicts, then use a text editor (or IDE) to resolve them. (The [Atom](https://atom.io/) text editor offers green and red buttons to facilitate this process.) Some releases will have more merge conflicts than others. Carefully progress through this process of resolving merge conflicts. Changes will usually include but are not limited to:
     * new configuration files
-    * new explanatory comments
     * new ISLE services optional or otherwise
     * new ISLE docker image tags
     * new comments
     * new documentation
 
-* Make the appropriate changes and then commit to your local
-    * `git add <changedfileshere>`
-    * `git commit -m "ISLE update from version # to version #"
+* After all merge conflicts are resolved, then add and commit your edits to your Local environment:
+    * **Example:** `git add <changedfileshere>`
+    * **Example:** `git commit -m "ISLE update from version #X to version #Y"`
 
-* You can choose to push this new branch to your remote git or keep it on your local. Ultimately after testing on your local, you'll merge to `master` and then deploy the new code to your `Staging` and `Production` environments.
+* Optional: If you want to backup this new branch to your origin, then run this command: (Ultimately after testing on your Local, you'll merge to `master` and then deploy the new code to your Staging and Production environments.)
+    * **Example:** `git push origin isle-update-numberhere`
 
-* On your local (personal computer), using the same open terminal, pull down the new containers. Be sure to be in the root of your ISLE project directory. Download the new ISLE images.
-    * `cd ~/yourprojecthere/`
+* Using the same open terminal, ensure you are in the root of your ISLE project directory:
+    * **Example:** `cd /path/to/your/repository`
+* Download the new ISLE docker images to the Local (personal computer):
     * `docker-compose pull`
 
-* Start up your existing local ISLE project with the new code and ISLE images.
+* Run the new docker containers (and new code) on your Local environment:
     * `docker-compose up -d`
 
-* QC your existing site and ensure the following:
-    * The site functions as it did before
-    * All services are functional and without apparent ERROR warnings in log console output.
+* In your web browser, enter the URL of your Local site:
+    * **Example:** `https://yourprojectnamehere.localdomain`
+* Quality control (QC) the Local site and ensure the following:
+    * The site appears and functions as it did prior to these updates.
     * You can ingest test objects without any issue.
     * You can modify existing object data without any issue.
+    * All services are functional and without apparent ERROR warnings in the browser log console output.
+        * **Example:** In Chrome, press the F12 button to open the [Console](https://developers.google.com/web/tools/chrome-devtools/console/), then select the "Console" tab.
 
-* Once testing has completed and any further adjustments have been made. Merge your `isle-update-numberhere` branch's code to `master`.
+* When you have completed testing and have no further adjustments to make, switch from your "isle-update-numberhere" branch of code to your "master" branch:
     * `git checkout master`
-    * `git merge isle-update-numberhere`
+* Merge your "isle-update-numberhere" branch of code to "master".
+    * **Example:** `git merge isle-update-numberhere`
 
 * Push this code to your online git provider ISLE
     * `git push -u origin master`
-    * This will take 2-5 mins depending on your internet speed.
+    * This will take 2-5 minutes depending on your internet speed.
 
-* Now you have the current ISLE project code checked into git as foundation to make changes on your `Staging` and `Production` servers.
+* You now have the current ISLE project code checked into git; this will be the foundation for making changes to your Staging and Production servers.
 
-## Staging Server Update
+## Update Staging Server
 
-* SSH into your `Staging` ISLE Host Server
-    * `ssh islandora@yourstagingserver.institution.edu`
-    * `cd /opt/yourprojecthere`
+* SSH into your Staging ISLE Host Server:
+    * **Example:** `ssh islandora@yourstagingserver.institution.edu`
+    * **Example:** `cd /opt/yourprojecthere`
 
-* Shut down the running containers
+* Stop and remove the existing ISLE containers:
     * `docker-compose down`
 
-* Update the docker files via git
-    * `git pull`
+* Update the docker files via git:
+    * `git pull origin master`
 
-* You'll need to fix the `.env` file again as you did in the `On Remote Staging - Edit the ".env" File to Change to the Staging Environment` stop of either the [Staging ISLE Installation: New Site](../install/install-staging-new.md) or the [Staging ISLE Installation: Migrate Existing Islandora Site](../install/install-staging-migrate.md) instructions. As described, this step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit that never gets pushed back to the git repository is critical to allow future ISLE updates or config changes. Basically you are just restoring what you had in the `.env` to the `Staging` settings in case they are overwriten.
+<!-- TODO: Break this down into simpler steps -->
+* You must now again fix the `.env` file as you did in the `On Remote Staging - Edit the ".env" File to Change to the Staging Environment` step of either the [Staging ISLE Installation: New Site](../install/install-staging-new.md) or the [Staging ISLE Installation: Migrate Existing Islandora Site](../install/install-staging-migrate.md) instructions. As described, this step is a multi-step, involved process that allows an end-user to make appropriate changes to the `.env` and then commit it locally to git. This local commit will never be pushed back to the git repository and this is critical because it allows future ISLE updates and/or configuration changes. In other words, you are restoring what you had in the `.env` to the Staging settings in case they are overwriten.
 
-* Download the new ISLE docker images on the remote Staging system
+* Download the new ISLE docker images to the remote Staging environment:
     * `docker-compose pull`
     * This may take a few minutes depending on your network connection
 
-* Run the new docker containers
+* Run the new docker containers (and new code) on your Staging environment:
     * `docker-compose up -d`
 
-The new containers should start up and your `Staging` Islandora site should be available, without any loss of existing content.
+The new containers should start up and your Staging Islandora site should be available, without any loss of existing content.
 
-* QC the existing ISLE `Staging` site and ensure the following:
-    * The site functions as it did before
-    * All services are functional and without apparent ERROR warnings in log console output.
+* QC the Staging site and ensure the following:
+    * The site appears and functions as it did prior to these updates.
     * You can ingest test objects without any issue.
     * You can modify existing object data without any issue.
+    * All services are functional and without apparent ERROR warnings in the browser log console output.
 
-* Recommend giving this installation a few days or a week at the minimum before repeating process on Production.
+* We recommend that you observe the above Staging installation for a few days or a week.
 
-If you run into trouble, please see the [Cleanup section of the quick start guide](https://github.com/Islandora-Collaboration-Group/ISLE#quick-stop-and-cleanup).
+## Update Production Server
+
+ When you are confident that your Staging installation is working as expected: 
+
+ * Repeat the same above "Update Staging Server" process but do so on your Production server environment.
+
+
+## Additional Resources
 
 Please post questions to the public [Islandora ISLE Google group](https://groups.google.com/forum/#!forum/islandora-isle), or subscribe to receive emails.


### PR DESCRIPTION
- Fixed code errant blocks
- Clearer instructions and descriptions
- Refactored "Update ISLE" documentation to increase end-user clarity, fixing some minor issues.
- Fixed: `docker-compose.yml` to be `docker-compose.demo.yml or docker-compose.local.yml`
- Fixed: added `-b` flag to correct this statement: `git checkout -b isle-update-numberhere`
- Removed link showing how to delete all volumes
- Added conditional `Demo or Local` with additional instructions for editing the `/etc/hosts` file
- Changed `nano` for simply using a text editor
- Identified duplicate `git clone of ISLE` and suggested fix for subsequent PR.
- Changing `descriptions in code blocks` to be "descriptions with quotations instead" (`code remains in code blocks`)
- Added initial step to `Install Local` docs to `Choose a Project Name`