### PR TITLE
We don't need to run CircleCI for GH Pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2
 jobs:
   build:
+    branches:
+      ignore:
+        - gh-pages
     machine: true
     working_directory: ~/isle
     parallelism: 1


### PR DESCRIPTION
Will ignore `gh-pages` branch on future CirCleCi runs