### PR TITLE
Adding specific date and note for 1.3.0 release

### DIFF
--- a/docs/release-notes/release-1-3-0.md
+++ b/docs/release-notes/release-1-3-0.md
@@ -1,8 +1,8 @@
-# Release Notes - ISLE v.1.3.0, 2019-09
+# Release Notes - ISLE v.1.3.0, 2019-09-27
 
 ### Contributions to this release from:
 
-* David Keiser-Clark (Williams College), documentation
+* David Keiser-Clark (Williams College), documentation and testing
 * Francesca Livermore (Wesleyan University), documentation
 * Gavin Morris (Born-Digital), code updates and testing
 * Mark McFate (Grinnell College), testing and documentation


### PR DESCRIPTION
- Adding specific release date and minor attribution note for 1.3.0 release.