### PR TITLE
Minor updates before Islandoracon

### DIFF
--- a/docs/about/about-isle.md
+++ b/docs/about/about-isle.md
@@ -1,6 +1,6 @@
 <!--- PAGE_TITLE --->
 
-[Islandora Enterprise (ISLE)](https://github.com/Islandora-Collaboration-Group/ISLE) is a new project in development that will address two of the most significant pain-points in Islandora: installation and maintenance.
+[ISLandora Enterprise (ISLE)](https://github.com/Islandora-Collaboration-Group/ISLE) is a new project in development that will address two of the most significant pain-points in Islandora: installation and maintenance.
 
 [Islandora](http://islandora.ca/) is an open-source software [framework](https://github.com/Islandora) designed to help institutions and organizations and their audiences collaboratively manage, and discover digital assets using a best-practices framework.
 

--- a/docs/about/project-history.md
+++ b/docs/about/project-history.md
@@ -1,4 +1,4 @@
-# ISLE: Islandora Enterprise
+# ISLandora Enterprise (ISLE)
 
 ## ISLE Documents
 * [ISLE Executive Summary](https://docs.google.com/document/d/17tAFxR6_b7sxXkE1teNDQZv0UZ0LLSkX8K05-U6A6nw/edit?usp=sharing) (project overview)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <!--- PAGE_TITLE --->
 
-# Islandora Enterprise (ISLE)
+# ISLandora Enterprise (ISLE)
 
 ISLE is a community developed open-source project that bundles the [Islandora](https://islandora.ca) stack into a set of [Docker](https://docker.com) images that are easy to install and update. ISLE allows for persistent customizations and provides a fully functioning Islandora platform for production, staging, and development digital repositories.
 

--- a/docs/install/install-environments.md
+++ b/docs/install/install-environments.md
@@ -2,7 +2,7 @@
 
 As of the ISLE `1.2.0` release, ISLE has the option to use clearly defined but different environments based on end user's needs. Depending on the environment choice, additional configuration changes will need to be made to ISLE configuration files, domain names, etc. We recommend that you install ISLE using the workflow and suggested order below.
 
-* **Demo** (Default) - Used for trying out ISLE for the first time, having a sandbox for tests etc
+* **Demo** - Used for trying out ISLE for the first time, having a sandbox for tests etc
 
 * **Local** - Used for Drupal site development, more extensive metadata, Solr and Fedora development work on a Local personal computer
 
@@ -18,7 +18,7 @@ The ISLE project `.env` file enables you to be define and launch a variety of IS
 
 * `.env` - 
   
-    * **Demo** (Default)
+    * **Demo**
         * `docker-compose.demo.yml`
             * `demo.env`
             * `config/apache/php_ini/php.demo.ini`

--- a/docs/optional-components/tickstack.md
+++ b/docs/optional-components/tickstack.md
@@ -1,4 +1,4 @@
-# TICK Stack: Dashboard Visualization for Systems Health and Log Records
+# TICK Stack: Dashboard Visualization for Systems Metrics and Logging Events
 
 ## Use Cases & User Stories
 

--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -19,7 +19,7 @@ We strongly recommend that you begin the update process on your Local environmen
 * On your Local (personal computer), open a terminal (Windows: open Git Bash) and navigate to your Local ISLE repository (this contains the "docker-compose.local.yml" file):
     * **Example:** `cd /path/to/your/repository`
 
-* Stop and remove the existing ISLE containers:
+* Stop the existing ISLE containers:
     * `docker-compose down`
 
 * Check your git remotes:
@@ -87,7 +87,7 @@ We strongly recommend that you begin the update process on your Local environmen
     * **Example:** `ssh islandora@yourstagingserver.institution.edu`
     * **Example:** `cd /opt/yourprojecthere`
 
-* Stop and remove the existing ISLE containers:
+* Stop the existing ISLE containers:
     * `docker-compose down`
 
 * Update the docker files via git:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Islandora Enterprise (ISLE)
-site_description: Documentation for Islandora Enterprise (ISLE)
+site_name: ISLandora Enterprise (ISLE)
+site_description: Documentation for ISLandora Enterprise (ISLE)
 
 site_dir: site
 docs_dir: docs


### PR DESCRIPTION
- Update ISLE: clarification made
- Removing "default" associated with "Demo" (it's not the default anymore)
- Minor update to TICK title
- tweaked font case: ISLandora Enterprise (ISLE)