### PR TITLE
Git cleanup doc script for isle140 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Please use the [ISLE Documentation](https://islandora-collaboration-group.github
 
 Due to removal of older files and folders and git changes in the ISLE git repository as of `November 28 2019`, please review the following:
 
-* If you are a **new** ISLE user and are cloning or forking this project for the first time after `November 28, 2019`, then **NO** you don't need to pay attention to this notice and can move on to the Quick Start section as needed.
+* If you are a **new** ISLE user and are cloning or forking this project for the first time after `November 28, 2019`, then you can **ignore this section and move on to the Quick Start section**.
 
-- If you have **previously forked or cloned** the ISLE project **prior to** `November 28, 2019`, then **YES** you do need to follow the instructions given in the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
+- If you have **previously forked or cloned** the ISLE project **prior to** `November 28, 2019`, then you **do need to follow the instructions** given in the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
 
 * If you still feel like you're not sure or cannot tell if you need to do this, then please refer to the instructions given in the `Identification Tools` section of the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
+
+- If you intend to submit pull requests (PRs) of any kind (documentation, code etc) to the ISLE project, ISLE maintainers will **NOT** accept PRs from repos that haven't had the script run on them as using an uncleaned forked repo will cause the removed files to return.
 
 ### Quick Start
 1. Please read: [ISLE Release Candidate (RC): How to Test](https://docs.google.com/document/d/1VUiI_bXo6SLqqUjmInVjBg3-cs40Vj7I_92txjFUoQg/edit#heading=h.1e4943m60lsh)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Please use the [ISLE Documentation](https://islandora-collaboration-group.github
 * Time required < 30 minutes.
 * **Windows Users**: Please open the .env and uncomment `COMPOSE_CONVERT_WINDOWS_PATHS=1`
 
+## **AS OF THE ISLE v.1.4.0 release in November 2019 (MANDATORY)**
+
+Due to removal of older files and folders and git changes in the ISLE git repository as of `November 28 2019`, please review the following:
+
+* If you are a **new** ISLE user and are cloning or forking this project for the first time after `November 28, 2019`, then **NO** you don't need to pay attention to this notice and can move on to the Quick Start section as needed.
+
+- If you have **previously forked or cloned** the ISLE project **prior to** `November 28, 2019`, then **YES** you do need to follow the instructions given in the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
+
+* If you still feel like you're not sure or cannot tell if you need to do this, then please refer to the instructions given in the `Identification Tools` section of the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
+
 ### Quick Start
 1. Please read: [ISLE Release Candidate (RC): How to Test](https://docs.google.com/document/d/1VUiI_bXo6SLqqUjmInVjBg3-cs40Vj7I_92txjFUoQg/edit#heading=h.1e4943m60lsh)
 2. Clone this repo

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Please use the [ISLE Documentation](https://islandora-collaboration-group.github
 
 ## **AS OF THE ISLE v.1.4.0 release in November 2019 (MANDATORY)**
 
-Due to removal of older files and folders and git changes in the ISLE git repository as of `November 28 2019`, please review the following:
+Due to removal of older files and folders and git changes in the ISLE git repository as of `November 25, 2019`, please review the following:
 
-* If you are a **new** ISLE user and are cloning or forking this project for the first time after `November 28, 2019`, then you can **ignore this section and move on to the Quick Start section**.
+* If you are a **new** ISLE user and are cloning or forking this project for the first time after `November 25, 2019`, then you can **ignore this section and move on to the Quick Start section**.
 
-- If you have **previously forked or cloned** the ISLE project **prior to** `November 28, 2019`, then you **do need to follow the instructions** given in the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
+- If you have **previously forked or cloned** the ISLE project **prior to** `November 25, 2019`, then you **do need to follow the instructions** given in the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
 
 * If you still feel like you're not sure or cannot tell if you need to do this, then please refer to the instructions given in the `Identification Tools` section of the [Cleanup ISLE git repository for Release v.1.4.0](https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/) documentation.
 

--- a/docs/assets/isle-v140-git-cleanup-script.sh
+++ b/docs/assets/isle-v140-git-cleanup-script.sh
@@ -83,7 +83,7 @@ echo "New size $sizeafter"
 echo ""
 echo ""
 
-echo "This script has now completed but there are more steps. Please continue to read the directions at https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup.md/"
+echo "This script has now completed but there are more steps. Please continue to read the directions at https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup/"
 
 echo ""
 

--- a/docs/assets/isle-v140-git-cleanup-script.sh
+++ b/docs/assets/isle-v140-git-cleanup-script.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+## Date: November 2019
+## This script isle-v140-git-cleanup-script.sh is for the express purpose of removing
+## files, binaries and folders from your forked or cloned ISLE project git repository. 
+## Please consult https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup.md/
+## Prior to running this script
+
+# Script will fail if a variable hasn’t been set.
+set -u
+
+# Script will exit immediately if a command fails.
+set -e
+
+echo ""
+
+echo ""
+
+echo "Type in the name of your git repo only e.g. ISLE (do not include .git) and then press the [ENTER] or [RETURN] key to continue"
+read -p 'Enter the name here:  ' reponame
+
+echo ""
+
+echo "Checking size of $reponame.git"
+function checksize {
+  du -sh $reponame.git
+}
+
+sizebefore=$(checksize)
+
+echo ""
+
+echo "Downloading BFG clean up tools about 13 MB"
+curl -o bfg-1.13.0.jar http://search.maven.org/classic/remotecontent?filepath=com/madgag/bfg/1.13.0/bfg-1.13.0.jar
+
+echo ""
+
+echo "Deleting files & folders. Please note this process will take 30 - 60 seconds with no output"
+java -jar bfg-1.13.0.jar --delete-files dg.localdomain.key $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files dg.localdomain.pem $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files docker-compose.DG-FEDORA.yml  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files fcrepo-drupalauthfilter-3.8.1.jar  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files fcrepo-installer-3.8.1.jar  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files fedoragsearch-2.8.1.zip  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files log4j-over-slf4j-1.6.6.jar  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files search_index.json  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files sitemap.xml  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files sitemap.xml.gz  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-files slf4j-jdk14-1.6.6.jar  $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-folders drupal $reponame.git > /dev/null 2>&1
+java -jar bfg-1.13.0.jar --delete-folders solr-4.10.4 $reponame.git > /dev/null 2>&1
+rm -rf $reponame.git.bfg-report
+
+echo "Finished deleting files & folders"
+
+
+echo ""
+
+echo "cd into the repository"
+cd $reponame.git || exit
+
+echo ""
+
+echo "Running Git commands"
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+
+echo ""
+
+echo "cd back to parent directory"
+cd ../ || exit
+
+echo ""
+
+echo "Checking size of $reponame.git"
+function checksize {
+  du -sh $reponame.git
+}
+
+sizeafter=$(checksize)
+
+echo "Old size $sizebefore"
+echo "New size $sizeafter"
+
+echo ""
+echo ""
+
+echo "This script has now completed but there are more steps. Please continue to read the directions at https://islandora-collaboration-group.github.io/ISLE/cookbook-recipes/isle-v140-git-cleanup.md/"
+
+echo ""
+
+exit

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -1,0 +1,161 @@
+As a result of the ISLE Phase II Sprint F - Optimize Docker Images in Fall 2019, the ISLE repository has had several changes:
+
+* Original ISLE git repo size was ~182 MB and would take a minimum of 10 -15 seconds or more to clone (_depending on one's Internet connection_)
+
+- The cleaned up ISLE git repo size is now 6.6 MB and should take a minimum of less than 3 seconds to clone (_depending on one's Internet connection_)
+
+* a clean up script along with this documentation was created and run on the ISLE repository for the ISLE v.1.4.0 release.
+
+- Any new pull request will have to be created from a forked or cloned ISLE repository that has had this cleanup process performed on it.
+
+---
+
+## **AS OF THE ISLE v.1.4.0 release in November 2019** All ISLE endusers are asked to run this script following the criteria below in the `Do I need to run this script? section.`
+
+---
+
+## Do I need to run this script?
+
+* If you are a new ISLE user and are cloning or forking this project for the first time, then **NO** you don't need to run the script below.
+
+- If you have previously forked or cloned the ISLE project **prior to** November 28, 2019, then **YES** you do need to run the script below.
+
+* If you still feel like you're not sure or cannot tell if you need to do this, please refer to the instructions below in the **Identification Tools** section.
+
+There is a brief description of what the script actually does found below in the **Script commands - explained** section.
+
+---
+
+## Git cleanup process
+
+
+### Git cleanup process - Overview
+
+The steps below in the section `Git cleanup process` will have you perform the following:
+
+* Open up a terminal and perform steps as directed
+- Make a directory called `ISLE_140_GIT_CLEANUP` on your laptop or workstation to perform all of these steps and collect all materials
+* Download the git cleanup script (`isle-v140-git-cleanup-script.sh`)and move it to the `ISLE_140_GIT_CLEANUP` directory
+- `git clone --mirror` your forked or cloned ISLE project directory to the `ISLE_140_GIT_CLEANUP` directory
+* Run the git cleanup script. It will prompt you to only enter the name of your forked or cloned ISLE project directory.
+- `git push` back the changes to your remote forked or cloned ISLE project directory.
+* Clone down your newly changed and smaller forked or cloned ISLE project directory again to ensure that the repositiory is smaller to a location of your choice.
+- Remove all previous larger size versions of your forked or cloned ISLE project directory. You can now delete the `ISLE_140_GIT_CLEANUP` directory and its contents.
+* Work from the newly resized and smaller forked or cloned ISLE project directory.
+  
+### Git cleanup process - Steps
+
+* Open up a terminal
+
+* Change directory to a location of your choice
+  * `cd your_path_here`
+
+* Make a new temporary direcotory called `ISLE_140_GIT_CLEANUP`
+    * `mkdir ISLE_140_GIT_CLEANUP`
+
+* Download the script found and save it to the `ISLE_140_GIT_CLEANUP` directory and fix the permissions.
+  * Right click on this link below and click "Save link as"
+    * [isle-v140-git-cleanup-script.sh](../assets/isle-v140-git-cleanup-script.sh)
+  * `chmod 755 isle-v140-git-cleanup-script.sh`
+
+* Run this git command to clone your forked or cloned ISLE project directory. This is not the usual `git clone` command, note the `--mirror` flag.
+  * `git clone --mirror git project url`
+  * Example:
+    * `git clone --mirror git@github.com:username/ISLE.git` (_as a fork using the same project name or title_)
+    * `git clone --mirror git@github.com:username/acmeorg_isle.git` (_as a fork or cloned repo using a different project name or title_)
+  * This will create a new directory called `ISLE.git` or `acmeorg_isle.git` which is not typical clone or fork output.
+
+* Run the cleanup script
+  * `./isle-v140-git-cleanup-script.sh`
+
+* At the start of the script, there will be an interactive input prompt asking you to:
+  
+```bash
+"Type in the name of your git repo only e.g. ISLE (do not include .git) and then press the [ENTER] or [RETURN] key to continue"`
+Enter the name here:  
+```
+* Enter the name of your forked or cloned ISLE git repository without the .git extension e.g `ISLE` or `acmeorg-isle` etc.
+
+* The script will continue and the process takes about 30 - 45 seconds depending on the speed of your system with minimal output.
+
+* Your final step is to push this local smaller repo back to the remote repository
+* `git push origin master`
+
+* Clone down your newly changed and smaller forked or cloned ISLE project directory again to ensure that the repositiory is smaller to a location of your choice.
+
+- Remove all previous larger size versions of your forked or cloned ISLE project directory. You can now delete the `ISLE_140_GIT_CLEANUP` directory and its contents.
+
+* Work from the newly resized and smaller forked or cloned ISLE project directory.
+
+---
+
+
+## Identification tools
+
+If you would like to check if the files have been removed or are still present:
+
+* Clone this [repo](https://github.com/ivantikal/git-tools.git) to pinpoint offending files and folders to the parent directory of where your local forked or cloned ISLE git repository is located. **Do not** clone this tool into your local forked or cloned ISLE git repository.
+  * `git clone https://github.com/ivantikal/git-tools.git`
+  * Your parent directory should now look like this: (_again please note your local forked or cloned ISLE git repository may not use the ISLE as the title_)
+
+```bash
+  directory/
+  ├── git-tools
+  └── ISLE
+```
+
+* Run the tools against your existing local forked or cloned ISLE git repository.
+  * **Example** usage for finding the 50 biggest files or folders in your local forked or cloned ISLE git repository. You can swap out the `ISLE` for the name of your forked or cloned ISLE project git repository.
+    * `./git-tools/clean-binaries/get_biggest_files_in_history.sh -r ./ISLE/ -n 50`
+
+* Review the resulting file to see if any of the files and folders listed in the `Files & Folder removed` section appear.
+  * `cat ./git-tools/clean-binaries/get_biggest_files_in_history.sh.tmp/bigtosmall.txt`
+
+* If none of the files appear, you don't need to run the script.
+
+* If **any** of the files or folders appear, you **have** to run the script. Scroll back up to the top of this document and follow the steps as provided.
+
+* More information can be found here on to use this [tool](https://www.tikalk.com/posts/2017/04/19/delete-binaries-from-git-repository/)
+
+---
+
+## Files & Folder removed
+
+* Over 176 MB of errant blobs, binaries and code were identified and removed.
+
+Files removed:
+
+```bash
+dg.localdomain.key
+dg.localdomain.pem
+docker-compose.DG-FEDORA.yml
+fcrepo-drupalauthfilter-3.8.1.jar
+fcrepo-installer-3.8.1.jar
+fedoragsearch-2.8.1.zip
+log4j-over-slf4j-1.6.6.jar
+search_index.json
+sitemap.xml
+sitemap.xml.gz
+slf4j-jdk14-1.6.6.jar
+```
+
+Folders (and files within) removed:
+```bash
+drupal
+solr-4.10.4
+```
+
+## Script commands - explained
+
+You are welcome to open up the `isle-v140-git-cleanup-script.sh` in a text editor to review its contents prior to running.
+
+Essentially `isle-v140-git-cleanup-script.sh` will perform the following:
+
+* Download the [BFG-repo-cleaner](https://rtyley.github.io/bfg-repo-cleaner/) jar file `bfg-1.113.0.jar`
+
+* Run the appropriate BFG java commands to delete files and folders
+
+* Run these git commands on your forked or cloned ISLE git repo
+  * `git reflog expire --expire=now --all && git gc --prune=now --aggressive`
+
+* **Please note:** This script will **not** push back to your source repo. That you need to do manually.

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -4,23 +4,21 @@ As a result of the ISLE Phase II Sprint F - Optimize Docker Images in Fall 2019,
 
 - The cleaned up ISLE git repo size is now 6.6 MB and should take a minimum of less than 3 seconds to clone (_depending on one's Internet connection_)
 
-* a clean up script along with this documentation was created and run on the ISLE repository for the ISLE v.1.4.0 release.
+* a new clean up script called [isle-v140-git-cleanup-script.sh](../assets/isle-v140-git-cleanup-script.sh) has been added along with this documentation created for endusers to run on their ISLE repository.
 
 - Any new pull request will have to be created from a forked or cloned ISLE repository that has had this cleanup process performed on it.
 
 ---
 
-## **AS OF THE ISLE v.1.4.0 release in November 2019** All ISLE endusers are asked to run this script following the criteria below in the "Do I need to run this script? section."
+## **AS OF THE ISLE v.1.4.0 release in November 2019 (MANDATORY)**
 
----
+Due to removal of older files and folders and git changes in the ISLE git repository as of `November 25, 2019`, please review the following:
 
-## Do I need to run this script?
+* If you are a **new** ISLE user and are cloning or forking this project for the first time after `November 25, 2019`, then you can **ignore this documentation** and move on to the Quick Start section within the README.md as needed.
 
-* If you are a new ISLE user and are cloning or forking this project for the first time, then **NO** you don't need to run the script below.
+- If you have **previously forked or cloned** the ISLE project **prior to** `November 25, 2019`, then you **do need to follow the instructions** given in this documentation.
 
-- If you have previously forked or cloned the ISLE project **prior to** November 28, 2019, then **YES** you do need to run the script below.
-
-* If you still feel like you're not sure or cannot tell if you need to do this, please refer to the instructions below in the **Identification Tools** section.
+* If you still feel like you're not sure or cannot tell if you need to do this, then please refer to the instructions given in the `Identification Tools` section below within this documentation.
 
 - If you intend to submit pull requests (PRs) of any kind (documentation, code etc) to the ISLE project, ISLE maintainers will **NOT** accept PRs from repos that haven't had the script run on them as using an uncleaned forked repo will cause the removed files to return.
 

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -22,6 +22,8 @@ As a result of the ISLE Phase II Sprint F - Optimize Docker Images in Fall 2019,
 
 * If you still feel like you're not sure or cannot tell if you need to do this, please refer to the instructions below in the **Identification Tools** section.
 
+- If you intend to submit pull requests (PRs) of any kind (documentation, code etc) to the ISLE project, ISLE maintainers will **NOT** accept PRs from repos that haven't had the script run on them as using an uncleaned forked repo will cause the removed files to return.
+
 There is a brief description of what the script actually does found below in the **Script commands - explained** section.
 
 ---

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -51,11 +51,10 @@ The steps below in the section `Git cleanup process` will have you perform the f
   * `cd your_path_here`
 
 * Make a new temporary direcotory called `ISLE_140_GIT_CLEANUP`
-    * `mkdir ISLE_140_GIT_CLEANUP`
+  * `mkdir ISLE_140_GIT_CLEANUP`
 
 * Download the script found and save it to the `ISLE_140_GIT_CLEANUP` directory and fix the permissions.
-  * Right click on this link below and click "Save link as"
-    * [isle-v140-git-cleanup-script.sh](../assets/isle-v140-git-cleanup-script.sh)
+  * `wget https://raw.githubusercontent.com/Islandora-Collaboration-Group/ISLE/docs/assets/isle-v140-git-cleanup-script.sh`
   * `chmod 755 isle-v140-git-cleanup-script.sh`
 
 * Run this git command to clone your forked or cloned ISLE project directory. This is not the usual `git clone` command, note the `--mirror` flag.

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -94,11 +94,13 @@ Enter the name here:
 
 ## Identification tools
 
+* **Please note:** In some of the examples given below, the title and/or names of the git repository examples use ISLE; your forked or cloned repo may be using a different project name or title, so please replace the `ISLE` for the name of your forked or cloned ISLE project git repository instead.
+
 If you would like to check if the files have been removed or are still present:
 
-* Clone this [repo](https://github.com/ivantikal/git-tools.git) to pinpoint offending files and folders to the parent directory of where your local forked or cloned ISLE git repository is located. **Do not** clone this tool into your local forked or cloned ISLE git repository.
+* Clone this [repo](https://github.com/ivantikal/git-tools.git) to pinpoint offending files and folders to the parent directory of where your local forked or cloned ISLE git repository is located. **Do not** clone this tool **into** your local forked or cloned ISLE git repository.
   * `git clone https://github.com/ivantikal/git-tools.git`
-  * Your parent directory should now look like this: (_again please note your local forked or cloned ISLE git repository may not use the ISLE as the title_)
+  * Your parent directory should now look like this example below: (_again please note your local forked or cloned ISLE git repository might not use the ISLE as the title_)
 
 ```bash
   directory/

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -10,7 +10,7 @@ As a result of the ISLE Phase II Sprint F - Optimize Docker Images in Fall 2019,
 
 ---
 
-## **AS OF THE ISLE v.1.4.0 release in November 2019** All ISLE endusers are asked to run this script following the criteria below in the `Do I need to run this script? section.`
+## **AS OF THE ISLE v.1.4.0 release in November 2019** All ISLE endusers are asked to run this script following the criteria below in the "Do I need to run this script? section."
 
 ---
 

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -64,8 +64,8 @@ The steps below in the section `Git cleanup process` will have you perform the f
   * `git clone --mirror git project url`
   * Example:
     * `git clone --mirror git@github.com:username/ISLE.git` (_as a fork using the same project name or title_)
-    * `git clone --mirror git@github.com:username/acmeorg_isle.git` (_as a fork or cloned repo using a different project name or title_)
-  * This will create a new directory called `ISLE.git` or `acmeorg_isle.git` which is not typical clone or fork output.
+    * `git clone --mirror git@github.com:username/yourreponame-isle.git` (_as a fork or cloned repo using a different project name or title_)
+  * This will create a new directory called `ISLE.git` or `yourreponame-isle.git` which is not typical clone or fork output.
 
 * Run the cleanup script
   * `./isle-v140-git-cleanup-script.sh`
@@ -76,7 +76,7 @@ The steps below in the section `Git cleanup process` will have you perform the f
 "Type in the name of your git repo only e.g. ISLE (do not include .git) and then press the [ENTER] or [RETURN] key to continue"`
 Enter the name here:  
 ```
-* Enter the name of your forked or cloned ISLE git repository without the .git extension e.g `ISLE` or `acmeorg-isle` etc.
+* Enter the name of your forked or cloned ISLE git repository without the .git extension e.g `ISLE` or `yourreponame-isle` etc.
 
 * The script will continue and the process takes about 30 - 45 seconds depending on the speed of your system with minimal output.
 
@@ -94,7 +94,7 @@ Enter the name here:
 
 ## Identification tools
 
-* **Please note:** In some of the examples given below, the title and/or names of the git repository examples use ISLE; your forked or cloned repo may be using a different project name or title, so please replace the `ISLE` for the name of your forked or cloned ISLE project git repository instead.
+* **Please note:** In some of the examples given below, the title and/or names of the git repository examples use ISLE; your forked or cloned repo may be using a different project name or title, so please replace the `ISLE` for the name of your forked or cloned ISLE project git repository instead e.g. `yourreponame-isle`.
 
 If you would like to check if the files have been removed or are still present:
 
@@ -109,7 +109,7 @@ If you would like to check if the files have been removed or are still present:
 ```
 
 * Run the tools against your existing local forked or cloned ISLE git repository.
-  * **Example** usage for finding the 50 biggest files or folders in your local forked or cloned ISLE git repository. You can swap out the `ISLE` for the name of your forked or cloned ISLE project git repository.
+  * **Example** usage for finding the 50 biggest files or folders in your local forked or cloned ISLE git repository. You can swap out the `ISLE` for the name of your forked or cloned ISLE project git repository e.g. `yourreponame-isle`
     * `./git-tools/clean-binaries/get_biggest_files_in_history.sh -r ./ISLE/ -n 50`
 
 * Review the resulting file to see if any of the files and folders listed in the `Files & Folder removed` section appear.

--- a/docs/cookbook-recipes/isle-v140-git-cleanup.md
+++ b/docs/cookbook-recipes/isle-v140-git-cleanup.md
@@ -64,8 +64,8 @@ The steps below in the section `Git cleanup process` will have you perform the f
   * `git clone --mirror git project url`
   * Example:
     * `git clone --mirror git@github.com:username/ISLE.git` (_as a fork using the same project name or title_)
-    * `git clone --mirror git@github.com:username/yourreponame-isle.git` (_as a fork or cloned repo using a different project name or title_)
-  * This will create a new directory called `ISLE.git` or `yourreponame-isle.git` which is not typical clone or fork output.
+    * `git clone --mirror git@github.com:username/yourprojectnamehere-isle.git` (_as a fork or cloned repo using a different project name or title_)
+  * This will create a new directory called `ISLE.git` or `yourprojectnamehere-isle.git` which is not typical clone or fork output.
 
 * Run the cleanup script
   * `./isle-v140-git-cleanup-script.sh`
@@ -76,7 +76,7 @@ The steps below in the section `Git cleanup process` will have you perform the f
 "Type in the name of your git repo only e.g. ISLE (do not include .git) and then press the [ENTER] or [RETURN] key to continue"`
 Enter the name here:  
 ```
-* Enter the name of your forked or cloned ISLE git repository without the .git extension e.g `ISLE` or `yourreponame-isle` etc.
+* Enter the name of your forked or cloned ISLE git repository without the .git extension e.g `ISLE` or `yourprojectnamehere-isle` etc.
 
 * The script will continue and the process takes about 30 - 45 seconds depending on the speed of your system with minimal output.
 
@@ -94,7 +94,7 @@ Enter the name here:
 
 ## Identification tools
 
-* **Please note:** In some of the examples given below, the title and/or names of the git repository examples use ISLE; your forked or cloned repo may be using a different project name or title, so please replace the `ISLE` for the name of your forked or cloned ISLE project git repository instead e.g. `yourreponame-isle`.
+* **Please note:** In some of the examples given below, the title and/or names of the git repository examples use ISLE; your forked or cloned repo may be using a different project name or title, so please replace the `ISLE` for the name of your forked or cloned ISLE project git repository instead e.g. `yourprojectnamehere-isle`.
 
 If you would like to check if the files have been removed or are still present:
 
@@ -109,7 +109,7 @@ If you would like to check if the files have been removed or are still present:
 ```
 
 * Run the tools against your existing local forked or cloned ISLE git repository.
-  * **Example** usage for finding the 50 biggest files or folders in your local forked or cloned ISLE git repository. You can swap out the `ISLE` for the name of your forked or cloned ISLE project git repository e.g. `yourreponame-isle`
+  * **Example** usage for finding the 50 biggest files or folders in your local forked or cloned ISLE git repository. You can swap out the `ISLE` for the name of your forked or cloned ISLE project git repository e.g. `yourprojectnamehere-isle`
     * `./git-tools/clean-binaries/get_biggest_files_in_history.sh -r ./ISLE/ -n 50`
 
 * Review the resulting file to see if any of the files and folders listed in the `Files & Folder removed` section appear.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
   - 'Setting Up and Testing the Islandora Multi Importer (IMI) Module': 'cookbook-recipes/multi_importer_installation.md'
   - 'Example AWS Storage Configuration': 'cookbook-recipes/example-aws-configuration.md'
   - 'How to Boot From External Drive': 'cookbook-recipes/boot-from-external-drive.md'
+  - 'Cleanup ISLE git repository for Release v.1.4.0': 'cookbook-recipes/isle-v140-git-cleanup.md'
   - 'Finding and Using Documentation for a Previous Release': 'cookbook-recipes/previous-release-docs.md'
 
 - 'About':


### PR DESCRIPTION
- Please find in the PR for release the following:
- Updated `mkdocs.yml` for the addition of this new git cleanup page
- modified:   README.md to warn users about git changes
- Added a new  docs/assets/isle-v140-git-cleanup-script.sh Endusers can download from here without having issues with mkdocs
- The script has minimal output @bseeger per our discusion
- Added docs/cookbook-recipes/isle-v140-git-cleanup.md for complete instructions on how to run the script

@dwk2 & @noahwsmith Adding you as extra reviewers just in case you are interested in the communication and wording. No need to feel that you have to respond but feedback most welcome.

@marksandford & @bseeger I'd ask for some light editing in the docs and testing please. I have tested this already on a recent clone of ISLE and it passes.
