### PR TITLE
Instructions regarding customizing Behat test suite

### DIFF
--- a/docs/optional-components/automated-testing.md
+++ b/docs/optional-components/automated-testing.md
@@ -4,7 +4,7 @@
 
 * Early in the history of ISLE, we did all build tests manually. We even developed a [checklist spreadsheet for it](https://docs.google.com/spreadsheets/d/1L-wrivXq2pUz7vcGsMCx3X7yKf27uokoaR8SovU_BsU/edit#gid=0).
     * The test coverage section of this document identifies (by Spreadsheet id number) where in the test suite we have addressed the testing requirement.
-    * The tests themselves are currently in a temporary location: https://github.com/Born-Digital-US/isle-ingest-samples/tree/master/behat
+    * The tests now inhabit a separate repo: https://github.com/Islandora-Collaboration-Group/isle-behat
 * ISLE Phase 2 included budget to automate this test suite, and to make it easy to trigger for various ISLE use cases on every build, as well as for use by implementing institutions to check the integrity of their ISLE builds.
 * We chose to use Behat to do behavioral testing as it is the most similar to an end-user, and ultimately we want to make sure that ISLE delivers a good end-user experience. Running Unit tests was deemed insufficient, as it only tests programmatic aspects, not whether the Drupal UI allows utilization of Islandora's features.
 * We chose to use Selenium and Chrome as Docker sidecars for actually executing the tests.
@@ -114,9 +114,48 @@ docker exec -it isle-apache-td bash -c "cd /var/www/html/sites/behat && ./run-is
 docker exec -it isle-apache-td bash -c "cd /var/www/html/sites/behat && ./run-isle-tests.sh --run=apache"
 ```
 
-## Additional Notes
-* If you have your own ISLE already, just omit that initial `git clone` for ISLE. If you use the script, we're assuming you've cloned our whole repository, switched to the `travis` branch, and are running it from there.
-* Modifications to tests may be necessary based on your institutional theme and configuration.
+## Customizing Your Own Behat Suite
+* If you are interested in customizing the Behat suite so that you can run it in a test environment against your themed site, follow these directions. Once you have the tests passing, you could run this in other environments - one important goal of the test suite creation was to "do no harm."
+* Create your own fork of isle-behat found at https://github.com/Islandora-Collaboration-Group/isle-behat
+* In your ISLE installation, edit your `.circleci/config.yml` file to pull in your customized behat repo instead of the generic repo. Edit this snippet:
+  * Replace the url to the generic isle-behat repo with the one for your specific behat repo:
+
+    ```bash
+    - run:
+      name: Fetch behat suite repo
+      command: |
+        mkdir data
+        cd ~/isle
+        git clone https://github.com/Islandora-Collaboration-Group/isle-behat.git isle-behat
+    ```
+
+  * If your test repo is not public then you will want to clone it using ssh instead of https.  In this case you will need to create and add an ssh key to your `.circleci/config.yml` file using these instructions: https://circleci.com/docs/2.0/add-ssh-key/ and https://circleci.com/docs/2.0/gh-bb-integration/
+  * Edit your `.circleci/config.yml` file to use your code, database, and Drupal files, instead of those for a generic ISLE installation.
+    * First get a copy of your database and drupal files.  Then put them in a location where CircleCi will be able to access them. This works best if you put them in a location that allows SSH access.
+    * Then comment out this section:
+
+      ```bash
+        - run:
+         name: Start container and verify that it works
+         command: |
+           set -x
+           docker exec -it isle-apache-td bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh
+         no_output_timeout: 20m
+      ```
+
+    * Next add in steps that fetch your sql database and drupal files from your pre-created location.  When writing these steps it will be useful to compare the steps in the `.circleci/config.yml` to the steps necessary to create your local, as you will need to import your database into your docker container, among other steps.
+    * Add steps that will disable any security features that might prevent Behat from logging in to the test environment version of your site.
+      * One example of this is CAS, or any other LDAP/SSO integration. If you need to disable CAS add in this step, or customize to your needs:
+
+        ```bash
+        - run:
+          name: Disable CAS
+          command: |
+            docker exec -it isle-apache-td bash -c "cd /var/www/html/ && drush dis cas -y"
+        ```
+
+    * Start running CircleCi. Problem solve by editing your Behat tests as necessary, pushing changes to your new institutional `isle-behat` fork. Add the ICG `isle-behat` as an upstream so you can pull in future updates just like you do with your main `ISLE` repo.
+    * When you first run the automated test suite it is quite likely that you will have some failures.  You will then need to edit your specific behat tests to address differences between your site and a generic Islandora site.
 
 ---
 


### PR DESCRIPTION
Instructions courtesy of @fedunham regarding running custom Behat tests on themed Islandora sites. Coincides with updates to Behat suite to be less brittle regarding themed Islandora sites: https://github.com/Islandora-Collaboration-Group/isle-behat/pull/1

Changes to the Behat suite:
- Removed portainer test since many folks won't run that in all environments
- Added an @disabled tag to allow folks to easily disable unwanted features
- Added tags to run for cleanup, to recover from failed test runs @teardown-only and @teardown-full
- Removed theme-specific search results phrasing tests
- Made the "find" command work better on customized themes