### PR TITLE
Fix permissions path in step 9

### DIFF
--- a/docs/install/install-staging-migrate.md
+++ b/docs/install/install-staging-migrate.md
@@ -294,7 +294,7 @@ Please clone from your existing Production Islandora git repository.
 * `git clone git@yourgitproviderhere.com/yourinstitutionhere/yourprojectnamehere-islandora.git /opt/data/apache/html`
 
 * Fix the permissions so that the `islandora` user has access.
-    * `sudo chown -Rv islandora:islandora /opt/yourprojectnamehere-islandora`
+    * `sudo chown -Rv islandora:islandora /opt/data/apache/html`
 
 ---
 


### PR DESCRIPTION
Step 9 tells you to clone your project into `/opt/data/apache/html`, and then tells you to change permissions at `/opt/yourprojectnamehere-islandora`. That second path doesn't exist; it is `/opt/data/apache/html`. This PR fixes that path.