### PR TITLE
Fixed broken URL in isle git cleanup script.sh

### DIFF
--- a/docs/assets/isle-v140-git-cleanup-script.sh
+++ b/docs/assets/isle-v140-git-cleanup-script.sh
@@ -30,7 +30,7 @@ sizebefore=$(checksize)
 echo ""
 
 echo "Downloading BFG clean up tools about 13 MB"
-curl -o bfg-1.13.0.jar http://search.maven.org/classic/remotecontent?filepath=com/madgag/bfg/1.13.0/bfg-1.13.0.jar
+curl -o bfg-1.13.0.jar https://repo1.maven.org/maven2/com/madgag/bfg/1.13.0/bfg-1.13.0.jar
 
 echo ""
 


### PR DESCRIPTION
The [maintainer](https://rtyley.github.io/bfg-repo-cleaner/) of the involved jar file moved the binary. I've updated the link from:

* `http://search.maven.org/classic/remotecontent?filepath=com/madgag/bfg/1.13.0/bfg-1.13.0.jar` (_results in a broken tiny binary and a silent error when running the script_.)

to 

* https://repo1.maven.org/maven2/com/madgag/bfg/1.13.0/bfg-1.13.0.jar (_results in correct 13 MB binary which completes entire script_)
