### PR TITLE
replacing offensive terms

### DIFF
--- a/docs/contributor-docs/style-guide.md
+++ b/docs/contributor-docs/style-guide.md
@@ -51,6 +51,7 @@ Mkdocs is finicky and requires double indentations to create properly indented s
 ---
 
 ## Terms We Use
+- allowlist/denylist (**we avoid using "whitelist" and "blacklist" due to stigma and racial stereotyping surrounding those terms**)
 - personal computer (**we use a generic term and NOT specific variants like:** laptop, workstation, desktop computer, or tablet, etc.)
 - repository (not "repo")
 - end users (not "endusers")

--- a/docs/cookbook-recipes/example-aws-configuration.md
+++ b/docs/cookbook-recipes/example-aws-configuration.md
@@ -59,7 +59,7 @@ Colgate primarily uses the Islandora Multi Importer (IMI) module for ingesting n
 The above workflow assumes the archivist has access to the AWS server
   - AWS block all ports by default.  A static IP address for anyone moving files to the server would be ideal.  Barring that, limiting the range to a library staff vlan would be better than opening the SSH port to all of campus.
   - SSH keys are required to connect to the AWS server.  There are various tools to generate these for Windows and Mac.  Amazon has [documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) on this process.
-  - At Colgate, provisions were made for a remote worker without a static IP address by setting up an rsync script to move files from a server on campus that the worker did have access to, to the AWS server.  This was preferred over whitelisting the entire VPN IP range, but setting that up is outside the scope of this document.
+  - At Colgate, provisions were made for a remote worker without a static IP address by setting up an rsync script to move files from a server on campus that the worker did have access to, to the AWS server.  This was preferred over allowlisting the entire VPN IP range, but setting that up is outside the scope of this document.
 
 ## Removing or Resizing the Ingest Volume
 

--- a/docs/optional-components/tickstack.md
+++ b/docs/optional-components/tickstack.md
@@ -197,7 +197,7 @@ The data from both systems will be collected, analyzed and accessed on / from th
 
 * A firewall configuration that allows incoming public traffic to port `8086` traffic
 
-* A firewall configuration that allows incoming private traffic access to port `8888`. It is recommended that this not be general public access but whitelisted to a select range of IP addresses given this will be the `Chronograf` dashboard port. Trusted users only please.
+* A firewall configuration that allows incoming private traffic access to port `8888`. It is recommended that this not be general public access but allowlisted to a select range of IP addresses given this will be the `Chronograf` dashboard port. Trusted users only please.
 
 * Only installation on Linux based host systems e.g. Debian / Ubuntu 18.04+ and Red Hat / CentOS 7.x+
     * Attempting to run TICK locally on a MacOS system can fail https://github.com/docker/for-mac/issues/3303


### PR DESCRIPTION
- We avoid using "whitelist" and "blacklist" due to stigma and racial stereotyping surrounding those terms
- Changed instances of "white list" (2) and "black list" (0) to “allowlist / denylist”
- Updated ISLE Style Guide
