### PR TITLE
Corrected ambiguous issue in toml file that led to user error

### DIFF
--- a/config/proxy/traefik.production.toml
+++ b/config/proxy/traefik.production.toml
@@ -36,16 +36,15 @@ defaultEntryPoints = ["http", "https"]
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
       ]
 
-# To use a Let's Encrypt SSL certificate
-# Leave this above section [entryPoints] as is / untouched
-# Scroll down to the Let's Encrypt section and uncomment all lines starting with [acme]
-# Modify values as needed or directed.
-# 
-# To use a Commercial SSL certificate
-# Replace .pem & .key with the name of your Production SSL certificate and associated key
-# Do note the positioning of the added lines. Third character indentation.
-# Example: 
-#    [entryPoints.https.tls]
+      # To use a Let's Encrypt SSL certificate
+      # Leave this above section [entryPoints] as is / untouched
+      # Scroll down to the Let's Encrypt section and uncomment all lines starting with [acme]
+      # Modify values as needed or directed.
+      #
+      # To use a Commercial SSL certificate
+      # Replace .pem & .key with the name of your Production SSL certificate and associated key
+      # Do note the positioning of the added lines. Third character indentation.
+      # Example: 
 #      [[entryPoints.https.tls.certificates]]
 #      certFile = "/certs/sitename.institution.edu.pem"
 #      keyFile = "/certs/sitename.institution.edu.key"
@@ -157,7 +156,7 @@ watch = true
 # Uncomment to use Letsencrypt instead of self-signed or commercial SSLs.
 # Change settings as needed. The email used should be for an admin level user or group account.
 # For additional reference please see: https://docs.traefik.io/configuration/acme/
-# 
+#
 #[acme]
 #  email = "admin@sitename.institution.edu"
 #  storage = "acme.json"

--- a/config/proxy/traefik.staging.toml
+++ b/config/proxy/traefik.staging.toml
@@ -36,16 +36,15 @@ defaultEntryPoints = ["http", "https"]
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
       ]
 
-# To use a Let's Encrypt SSL certificate
-# Leave this above section [entryPoints] as is / untouched
-# Scroll down to the Let's Encrypt section and uncomment all lines starting with [acme]
-# Modify values as needed or directed.
-# 
-# To use a Commercial SSL certificate
-# Replace .pem & .key with the name of your Staging SSL certificate and associated key
-# Do note the positioning of the added lines. Third character indentation.
-# Example: 
-#    [entryPoints.https.tls]
+      # To use a Let's Encrypt SSL certificate
+      # Leave this above section [entryPoints] as is / untouched
+      # Scroll down to the Let's Encrypt section and uncomment all lines starting with [acme]
+      # Modify values as needed or directed.
+      #
+      # To use a Commercial SSL certificate
+      # Replace .pem & .key with the name of your Staging SSL certificate and associated key
+      # Do note the positioning of the added lines. Third character indentation.
+      # Example: 
 #      [[entryPoints.https.tls.certificates]]
 #      certFile = "/certs/sitename-staging.institution.edu.pem"
 #      keyFile = "/certs/sitename-staging.institution.edu.key"
@@ -157,7 +156,7 @@ watch = true
 # Uncomment to use Letsencrypt instead of self-signed or commercial SSLs.
 # Change settings as needed. The email used should be for an admin level user or group account.
 # For additional reference please see: https://docs.traefik.io/configuration/acme/
-# 
+#
 #[acme]
 #  email = "admin@sitename-staging.institution.edu"
 #  storage = "acme.json"

--- a/docs/install/install-production-migrate.md
+++ b/docs/install/install-production-migrate.md
@@ -53,7 +53,7 @@ Please post questions to the public [Islandora ISLE Google group](https://groups
 
 * **RECOMMENDATION:** We recommend that you use a temporary domain name e.g. `https://yourprojectnamehere-newprod.institution.edu` to check the new Production ISLE site while an existing non-ISLE Production site is still running and compare for differences. This will also allow end users to still access the old Production system while the work for the new ISLE system is ongoing.
     * You'll need to add an additional A record for `yourprojectnamehere-newprod.institution.edu` to point to the same ISLE Production Host Server IP.
-    * Please adjust all involved domain names and configuration files accordingly. 
+    * Please adjust all involved domain names and configuration files accordingly.
     * When ready to launch the new ISLE production site publicly, you can remove the `-newprod` from all domain references and configuration files.
         * Update the DNS records to repoint the current non-ISLE Production server A record for `yourprojectnamehere.institution.edu` to the new ISLE host server IP.
         * Remove the temporary DNS A record for `yourprojectnamehere-newprod.institution.edu`
@@ -232,7 +232,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .cert**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/yourprojectnamehere.domain.cert"
       keyFile = "/certs/yourprojectnamehere.domain.key"
@@ -240,7 +239,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .pem**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/yourprojectnamehere.institution.edu.pem"
       keyFile = "/certs/yourprojectnamehere.institution.edu.key"
@@ -316,7 +314,7 @@ Please clone from your existing Production Islandora git repository.
         * You'll need to adjust the paths below in case your setup differs on either the non-ISLE Production server or the ISLE Production server.
         * Copy your `/usr/local/fedora/data/datastreamStore` data to the suggested path of `/mnt/data/fedora/datastreamStore`
             * You may need to change the permissions to `root:root` on the Production `/mnt/data/fedora/datastreamStore` directory above after copying so the Fedora container can access properly. Do not do this on your existing Production system please.
-    * Production Fedora `objectStore`. 
+    * Production Fedora `objectStore`.
         * Copy your `/usr/local/fedora/data/objectStore` data to the suggested path of `/opt/data/fedora/objectStore`
             * You may need to change the permissions to `root:root` on the Production `/opt/data/fedora/objectStore` above after copying so the Fedora container can access properly. Do not do this on your existing Production system please.
 
@@ -518,7 +516,7 @@ Depending on the size of your repository, this entire process may take minutes (
 
 ### Reindex Fedora RI & Fedora SQL Database (part 1 of 2)
 
-Since this command can take minutes or hours depending on the size of your repository, As such, it is recommended starting a screen session prior to running the following commands. Learn more about [screen here](https://www.tecmint.com/screen-command-examples-to-manage-linux-terminals/) 
+Since this command can take minutes or hours depending on the size of your repository, As such, it is recommended starting a screen session prior to running the following commands. Learn more about [screen here](https://www.tecmint.com/screen-command-examples-to-manage-linux-terminals/)
 
 **Note:** The method described below is a longer way of doing this process to onboard users.
 

--- a/docs/install/install-production-new.md
+++ b/docs/install/install-production-new.md
@@ -6,7 +6,7 @@ This Production ISLE Installation will use the themed Drupal website created dur
 
 While this installation will get you a brand new Production site, it is **not** intended as a migration process of a previously existing Islandora site. If you need to build a Production environment to migrate a previously existing Islandora site, please use the [Production ISLE Installation: Migrate Existing Islandora Site](../install/install-production-migrate.md) instead.
 
-As this Production domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your Production Host Server IP address in your institution's DNS records. 
+As this Production domain will require a real domain name or [FQDN](https://kb.iu.edu/d/aiuv), you will need to ask your IT department or appropriate resource for an "A record" to be added for your domain to "point" to your Production Host Server IP address in your institution's DNS records.
 
 Example:`https://yourprojectnamehere.institution.edu`
 
@@ -206,7 +206,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .cert**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/yourprojectnamehere.domain.cert"
       keyFile = "/certs/yourprojectnamehere.domain.key"
@@ -214,7 +213,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .pem**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/yourprojectnamehere.institution.edu.pem"
       keyFile = "/certs/yourprojectnamehere.institution.edu.key"
@@ -319,7 +317,7 @@ This step is a multi-step, involved process that allows an end-user to make appr
         * `COMPOSE_FILE=docker-compose.production.yml`
     * Save the file
 
-* For users of ISLE version 1.5 and above, these git instructions below are not needed. The .env file is no longer tracked in git. 
+* For users of ISLE version 1.5 and above, these git instructions below are not needed. The .env file is no longer tracked in git.
 
 * For users of ISLE versions 1.4.2 and below, you will need to continue to follow these instructions until you upgrade.
     * Enter `git status` - You'll now see the following:

--- a/docs/install/install-staging-migrate.md
+++ b/docs/install/install-staging-migrate.md
@@ -229,7 +229,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .cert**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/yourprojectnamehere-staging.domain.cert"
       keyFile = "/certs/yourprojectnamehere-staging.domain.key"
@@ -237,7 +236,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .pem**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/sitename-staging.institution.edu.pem"
       keyFile = "/certs/sitename-staging.institution.edu.key"

--- a/docs/install/install-staging-new.md
+++ b/docs/install/install-staging-new.md
@@ -205,7 +205,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .cert**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/yourprojectnamehere-staging.domain.cert"
       keyFile = "/certs/yourprojectnamehere-staging.domain.key"
@@ -213,7 +212,6 @@ If you have decided to use Commercial SSL certs supplied to you by your IT team 
 
 **Example: .pem**
 ```bash
-    [entryPoints.https.tls]
       [[entryPoints.https.tls.certificates]]
       certFile = "/certs/yourprojectnamehere-staging.institution.edu.pem"
       keyFile = "/certs/yourprojectnamehere-staging.institution.edu.key"
@@ -318,7 +316,7 @@ This step is a multi-step, involved process that allows an end-user to make appr
       * `COMPOSE_FILE=docker-compose.staging.yml`
     * Save the file
 
-* For users of ISLE version 1.5 and above, these git instructions below are not needed. The .env file is no longer tracked in git. 
+* For users of ISLE version 1.5 and above, these git instructions below are not needed. The .env file is no longer tracked in git.
 
 * For users of ISLE versions 1.4.2 and below, you will need to continue to follow these instructions until you upgrade.
     * Enter `git status` - You'll now see the following:


### PR DESCRIPTION
This is only for live Commercial SSL Certificates:

The [Staging and Production New and Migrate documentation pages](https://islandora-collaboration-group.github.io/ISLE/install/install-staging-migrate/#step-5-on-local-staging-if-using-commercial-ssls) show an example that appears to instruct the user to uncomment 4 lines. However, uncommenting the first of those 4 lines (`[entryPoints.https.tls]`) causes the Traefik container to immediately exit upon `docker-compose up -d`.

The solution is to remove that one offending line of example code: `[entryPoints.https.tls]`

This PR removes that line of code from both the `config/proxy/traefik.production.toml` and ` config/proxy/traefik.staging.toml` files, as well as the four related documentation files. 

NOTE: On my Windows10 box, I ran dos2unix on these 6 files, but GIT is still complaining that line endings will be changed. So YOU may want to re-run dos2unix.exe on these 6 files to ensure UNIX line endings. 
Git is showing this message on my local when I committed these to this branch:
```
$ git add .
warning: LF will be replaced by CRLF in config/proxy/traefik.production.toml.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in config/proxy/traefik.staging.toml.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in docs/install/install-production-migrate.md.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in docs/install/install-production-new.md.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in docs/install/install-staging-migrate.md.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in docs/install/install-staging-new.md.
The file will have its original line endings in your working directory
```