### PR TITLE
Editing migrate-dbs-utf8.md

### DIFF
--- a/docs/cookbook-recipes/migrate-dbs-utf8.md
+++ b/docs/cookbook-recipes/migrate-dbs-utf8.md
@@ -1,11 +1,11 @@
 # Migrate your MySQL databases to UTF8 format
 
-* Within the `ISLE/scripts/apache/` directory there is now a `db_utf8_migration.sh` script that can be run to migrate your site's MySQL databases to UTF8 format.
+* Within the `ISLE/scripts/apache/` directory there is now a `db_ut8f_migration.sh` script that can be run to migrate your site's MySQL databases to UTF8 format.
 
 * More information can be found [here]( https://www.drupal.org/project/utf8mb4_convert)
 
 * To use this script:
-  * `cp scripts/apache/db_utf8_migration.sh isle-apache-ld:/var/www/html`
+  * `docker cp scripts/apache/db_ut8f_migration.sh isle-apache-ld:/var/www/html`
   * `docker exec -it isle-apache-ld bash chmod 755 /var/www/html/db_utf8_migration.sh`
-  * `docker exec -it isle-apache-ld bash /var/www/html/db_utf8_migration.sh`
+  * `docker exec -it isle-apache-ld bash /var/www/html/db_ut8f_migration.sh`
   * Please note this process can take a minimum of 10-15 mins or more depending on your site size etc.


### PR DESCRIPTION
Adding missing `docker` command and correcting the name of the file to be as it exists in the file structure: `db_ut8f_migration` (yes, it's misspelled... but now this script will work.)