### PR TITLE
Add ISLE7 EOL message to some pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # ISLE: Islandora Enterprise (legacy)
 
-**Please note** For the latest ISLE, please use this repository instead: https://github.com/Islandora-Devops/isle-dc
-
+> [!WARNING] 
+> The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/). For the latest ISLE, please use the isle-dc repository instead: https://github.com/Islandora-Devops/isle-dc
+> 
 ## Introduction
 ISLE uses replaceable Docker images to streamline and largely automate the process of installing and maintaining the entire Islandora 7.x stack, while at the same time enabling institutions to create customizations that persist separately from core code. The result is the ability to easily, quickly and regularly update an institution’s entire Islandora stack. Maintaining ISLE requires significantly less time and staff, and also reduces the dependency on expert technical staff and outside vendors.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 # ISLandora Enterprise (ISLE)
 
+| WARNING |
+| :-------------      |
+| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/).|
+
 ISLE is a community developed open-source project that bundles the [Islandora](https://islandora.ca) stack into a set of [Docker](https://docker.com) images that are easy to install and update. ISLE allows for persistent customizations and provides a fully functioning Islandora platform for production, staging, and development digital repositories.
 
 ## How to Install ISLE

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 | WARNING |
 | :-------------      |
-| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/).|
+| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/). For the latest ISLE, please use the isle-dc repository instead: https://github.com/Islandora-Devops/isle-dc|
 
 ISLE is a community developed open-source project that bundles the [Islandora](https://islandora.ca) stack into a set of [Docker](https://docker.com) images that are easy to install and update. ISLE allows for persistent customizations and provides a fully functioning Islandora platform for production, staging, and development digital repositories.
 

--- a/docs/install/host-hardware-requirements.md
+++ b/docs/install/host-hardware-requirements.md
@@ -1,5 +1,9 @@
 # Hardware Requirements
 
+| WARNING |
+| :-------------      |
+| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/).|
+
 The ISLE host server can be a personal computer, physical server, virtual machine (VM) or cloud service. An SSH connection with a user that has root or admin privileges is necessary. 
 
 If you need help requesting a server environment, please see the [Sample IT Department Request Letter](../appendices/sample-it-department-request.md).
@@ -14,9 +18,10 @@ If you need help requesting a server environment, please see the [Sample IT Depa
 
 **Please select your hardware environment:**
 
-- [Production Server](#production-server)
-- [Staging Server](#staging-server)
-- [Personal Computer (Demo or Local)](#personal-computer-demo-or-local)
+- [Hardware Requirements](#hardware-requirements)
+  - [Production Server](#production-server)
+  - [Staging Server](#staging-server)
+  - [Personal Computer (Demo or Local)](#personal-computer-demo-or-local)
 
 ---
 

--- a/docs/install/host-hardware-requirements.md
+++ b/docs/install/host-hardware-requirements.md
@@ -2,7 +2,7 @@
 
 | WARNING |
 | :-------------      |
-| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/).|
+| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/). For the latest ISLE, please use the isle-dc repository instead: https://github.com/Islandora-Devops/isle-dc|
 
 The ISLE host server can be a personal computer, physical server, virtual machine (VM) or cloud service. An SSH connection with a user that has root or admin privileges is necessary. 
 

--- a/docs/install/install-environments.md
+++ b/docs/install/install-environments.md
@@ -1,5 +1,9 @@
 # Overview: ISLE Installation Environments
 
+| WARNING |
+| :-------------      |
+| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/).|
+
 As of the ISLE `1.2.0` release, ISLE has the option to use clearly defined but different environments based on end user's needs. Depending on the environment choice, additional configuration changes will need to be made to ISLE configuration files, domain names, etc. We recommend that you install ISLE using the workflow and suggested order below.
 
 * **Demo** - Used for trying out ISLE for the first time, having a sandbox for tests or to "kick the tires" on ISLE.

--- a/docs/install/install-environments.md
+++ b/docs/install/install-environments.md
@@ -2,7 +2,7 @@
 
 | WARNING |
 | :-------------      |
-| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/).|
+| The ISLE Legacy project (also known as ISLE7) is no longer actively supported by the Islandora community, except for some security updates. When creating new sites, please see the currently supported installation options found in the official Islandora community [documentation site](https://islandora.github.io/documentation/). For the latest ISLE, please use the isle-dc repository instead: https://github.com/Islandora-Devops/isle-dc|
 
 As of the ISLE `1.2.0` release, ISLE has the option to use clearly defined but different environments based on end user's needs. Depending on the environment choice, additional configuration changes will need to be made to ISLE configuration files, domain names, etc. We recommend that you install ISLE using the workflow and suggested order below.
 


### PR DESCRIPTION
To help cut down on folks accidentally considering using ISLE7 for new sites, I wanted to suggest adding some EOL warnings.

I used the table syntax as I saw it used as an sort of "admonition" in the following page, since I am not sure this version of MKdocs is set up for typical admonsition syntax.

https://islandora-collaboration-group.github.io/ISLE/install/host-hardware-requirements/

I can update my PR with actual admonition Markdown syntax and/or other message content changes if preferred.

